### PR TITLE
Razor engine update.

### DIFF
--- a/docs/content/literate.fsx
+++ b/docs/content/literate.fsx
@@ -259,4 +259,8 @@ version of the F# compiler:
    `<pre>` tag containing the original source code of the F# Script or Markdown document.
  - `errorHandler` - a function that is used to report errors from the F# compiler 
    (if not specified, errors are printed to the standard output)
+ - `assemblyReferences` - The assemblies to use when compiling Razor templates.
+   Use this parameter if templates fail to compile with mcs on linux or
+   if you need additional references in your templates.
+   (if not specified, we use the currently loaded assemblies)
 *)

--- a/docs/content/metadata.fsx
+++ b/docs/content/metadata.fsx
@@ -91,6 +91,27 @@ module Foo =
 Note that currently our code is not handling `<parameter>` and `<result> tags, this is 
 not so much of a problem given that given that FSharp.Formatting infers the signature via reflection.
 
+
+## Optional parameters
+
+All of the three methods discussed in the previous two sections take a number of optional
+parameters that can be used to tweak how the formatting works:
+
+ - `markDownComments` - specifies if you want to use the markdown parser for in-code comments.
+   With markDownComments enabled there is no support for `<see cref="">` links, so `false` is recommended for C# assemblies.
+   (if not specified, `true` is used)
+ - `typeTemplate` - the templates to be used for normal types (and C# types).
+   (if not specified, `"type.cshtml"` is used)
+ - `moduleTemplate` - the templates to be used for modules.
+   (if not specified, `"module.cshtml"` is used)
+ - `namespaceTemplate` - the templates to be used for namespaces.
+   (if not specified, `"namespaces.cshtml"` is used)
+ - `assemblyReferences` - The assemblies to use when compiling Razor templates.
+   Use this parameter if templates fail to compile with mcs on linux or
+   if you need additional references in your templates.
+   (if not specified, we use the currently loaded assemblies)
+
+
 Work in progress!
 -----------------
 

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -4,7 +4,7 @@ nuget FAKE
 nuget FSharp.Compiler.Service
 nuget CommandLineParser 1.9.71
 nuget Microsoft.AspNet.Razor == 2.0.30506.0
-nuget RazorEngine 3.5.0-beta3
+nuget RazorEngine 3.5.0
 nuget NUnit
 nuget NUnit.Runners
 nuget NuGet.CommandLine

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -3,8 +3,8 @@ source http://nuget.org/api/v2
 nuget FAKE
 nuget FSharp.Compiler.Service
 nuget CommandLineParser 1.9.71
-nuget Microsoft.AspNet.Razor 2.0.30506.0
-nuget RazorEngine 3.3.0
+nuget Microsoft.AspNet.Razor == 2.0.30506.0
+nuget RazorEngine 3.5.0-beta3
 nuget NUnit
 nuget NUnit.Runners
 nuget NuGet.CommandLine

--- a/paket.lock
+++ b/paket.lock
@@ -2,12 +2,12 @@ NUGET
   remote: http://nuget.org/api/v2
   specs:
     CommandLineParser (1.9.71)
-    FAKE (3.13.3)
+    FAKE (3.14.0)
     FSharp.Compiler.Service (0.0.81)
     Microsoft.AspNet.Razor (2.0.30506.0)
     NuGet.CommandLine (2.8.3)
     NUnit (2.6.4)
     NUnit.Runners (2.6.4)
-    RazorEngine (3.5.0-beta3)
+    RazorEngine (3.5.0)
       Microsoft.AspNet.Razor (>= 3.0.0) - >= net45
       Microsoft.AspNet.Razor (2.0.30506.0) - >= net40 < net45

--- a/paket.lock
+++ b/paket.lock
@@ -2,11 +2,12 @@ NUGET
   remote: http://nuget.org/api/v2
   specs:
     CommandLineParser (1.9.71)
-    FAKE (3.13.2)
+    FAKE (3.13.3)
     FSharp.Compiler.Service (0.0.81)
     Microsoft.AspNet.Razor (2.0.30506.0)
     NuGet.CommandLine (2.8.3)
     NUnit (2.6.4)
     NUnit.Runners (2.6.4)
-    RazorEngine (3.3.0)
-      Microsoft.AspNet.Razor (>= 2.0.30506.0)
+    RazorEngine (3.5.0-beta3)
+      Microsoft.AspNet.Razor (>= 3.0.0) - >= net45
+      Microsoft.AspNet.Razor (2.0.30506.0) - >= net40 < net45

--- a/src/Common/Razor.fs
+++ b/src/Common/Razor.fs
@@ -33,13 +33,19 @@ open RazorEngine
 open RazorEngine.Text
 open RazorEngine.Templating
 open RazorEngine.Configuration
+open RazorEngine.Compilation.ReferenceResolver
 
 type GetMemberBinderImpl (name) =
     inherit GetMemberBinder(name, false)
     let notImpl () = raise <| new NotImplementedException()
     override x.FallbackGetMember(v, sug) = notImpl()
 
-type RazorRender(layoutRoots, namespaces, templateName:string, ?model_type:System.Type) =
+type MyTemplateService (config) =
+    inherit TemplateService(config) 
+
+    member x.Resolver = config.Resolver
+
+type RazorRender(layoutRoots, namespaces, templateName:string, ?modeltype:System.Type, ?references : string list) =
   let templateName =
     if templateName.EndsWith(".cshtml") then
         templateName.Substring(0, templateName.Length - 7)
@@ -51,23 +57,25 @@ type RazorRender(layoutRoots, namespaces, templateName:string, ?model_type:Syste
         member x.Resolve name = 
             let key = Array.ofSeq layoutRoots, name
             templateCache.GetOrAdd (key, fun (layoutRoots, name) -> 
-                match RazorRender.Resolve(layoutRoots, name + ".cshtml") with
-                | Some file -> File.ReadAllText(file)
-                | None -> 
-                    failwithf "Could not find template file: %s\nSearching in: %A" name layoutRoots
-                    null)
-                 }
-  do RazorRender.Resolver <- templateResolver
+                File.ReadAllText(RazorRender.Resolve(layoutRoots, name + ".cshtml"))) }
 
   // Configure templating engine
   let config = new TemplateServiceConfiguration()
   do config.EncodedStringFactory <- new RawStringFactory()
   do config.Resolver <- templateResolver
+  do
+    match references with
+    | Some r -> 
+      config.ReferenceResolver <- 
+        { new IReferenceResolver with 
+            member x.GetReferences (_, _) =
+                r |> List.toSeq |> Seq.map (CompilerReference.From) }
+    | None -> ()
+
   do namespaces |> Seq.iter (config.Namespaces.Add >> ignore)
   do config.BaseTemplateType <- typedefof<DocPageTemplateBase<_>>
-  do config.Debug <- true        
-  let templateservice = new TemplateService(config)
-  do Razor.SetTemplateService(templateservice)
+  do config.Debug <- true 
+  let templateservice = new MyTemplateService(config)
 
   let handleCompile source f =
     try
@@ -97,57 +105,47 @@ type RazorRender(layoutRoots, namespaces, templateName:string, ?model_type:Syste
     for k, v in defaultArg properties [] do
       viewBag.AddValue(k, v)
     viewBag
-
-  /// Global resolver (for use in 'DocPageTempalateBase')
-  static member val Resolver = null with get, set
+  
   /// Find file in one of the specified layout roots
-  static member Resolve(layoutRoots, name) =
+  static member TryResolve(layoutRoots, name) =
     layoutRoots |> Seq.tryPick (fun layoutRoot ->
       let partFile = Path.Combine(layoutRoot, name)
       if File.Exists(partFile) then Some partFile else None)
-  static member ForceResolve(layoutRoots, name) =
-    match RazorRender.Resolve(layoutRoots, name) with
+  static member Resolve(layoutRoots, name) =
+    match RazorRender.TryResolve(layoutRoots, name) with
     | Some f -> f
     | None -> 
         failwithf "Could not find template file: %s\nSearching in: %A" name layoutRoots
-  static member Run<'m>(name, model:'m, viewBag:DynamicViewBag) =
-    if Razor.Resolve<'m>(name, model) = null then
-        let templateContent = RazorRender.Resolver.Resolve(name)
-        Razor.Compile(templateContent, (if obj.ReferenceEquals(model, null) then typeof<'m> else model.GetType()), name)
-    Razor.Run<'m>(name, model, viewBag)
       
   member internal x.HandleCompile source f = handleCompile source f
   member internal x.TemplateName = templateName
+  member internal x.TemplateService = templateservice
+  member internal x.TemplateResolver = templateResolver
   member internal x.WithProperties properties = withProperties properties x.ViewBag
 
   /// Dynamic object with more properties (?)
   member val ViewBag = new DynamicViewBag() with get, set
-  member x.ProcessFile(?properties) =
-    handleCompile templateName (fun _ ->
-      RazorRender.Run<obj>(templateName, null, x.WithProperties properties))
-  /// Process source file and return result as a string
-  member x.ProcessFileParse(?properties) = 
-    handleCompile templateName (fun _ ->
-      Razor.Parse(templateResolver.Resolve templateName, null, x.WithProperties properties, templateName))
+
+  member x.ProcessFile(?properties) = x.ProcessFileModel(null, ?properties = properties)
+  member x.ProcessFileParse(?properties) = x.ProcessFileParseModel(null, ?properties = properties)
       
   member x.ProcessFileModel(model:obj,?properties) =
     handleCompile templateName (fun _ ->
-      RazorRender.Run<obj>(templateName, model, x.WithProperties properties))
+      if templateservice.Resolve(templateName, model) = null then
+          let templateContent = templateResolver.Resolve(templateName)
+          templateservice.Compile(templateContent, model.GetType(), templateName)
+      templateservice.Run(templateName, model, x.WithProperties properties))
+
   /// Process source file and return result as a string
   member x.ProcessFileParseModel(model:obj, ?properties) = 
     handleCompile templateName (fun _ ->
-      Razor.Parse(templateResolver.Resolve templateName, model, x.WithProperties properties, templateName))
+      templateservice.Parse(templateResolver.Resolve templateName, model, x.WithProperties properties, templateName))
 
-and RazorRender<'model>(layoutRoots, namespaces, templateName) =
-    inherit RazorRender(layoutRoots, namespaces, templateName, typeof<'model>)
+and RazorRender<'model>(layoutRoots, namespaces, templateName, ?references) =
+    inherit RazorRender(layoutRoots, namespaces, templateName, modeltype = typeof<'model>, ?references = references)
 
-    member x.ProcessFile(model:'model, ?properties) =
-      x.HandleCompile x.TemplateName (fun _ ->
-        RazorRender.Run<'model>(x.TemplateName, model, x.WithProperties properties))
-    /// Process source file and return result as a string
-    member x.ProcessFileParse(model:'model, ?properties) = 
-      x.HandleCompile x.TemplateName (fun _ ->
-        Razor.Parse<'model>(RazorRender.Resolver.Resolve x.TemplateName, model, x.WithProperties properties, x.TemplateName))
+    member x.ProcessFile(model:'model, ?properties) = x.ProcessFileModel(model, ?properties = properties)
+    member x.ProcessFileParse(model:'model, ?properties) = x.ProcessFileParseModel(model, ?properties = properties)
 
 and StringDictionary(dict:IDictionary<string, string>) =
   member x.Dictionary = dict
@@ -196,8 +194,8 @@ and [<AbstractClass>] DocPageTemplateBase<'T>() =
     and set (value:StringDictionary) = x.trySetViewBagValue<IDictionary<string, string>> "Properties" value.Dictionary
 
   member x.Root = x.Properties.["root"]   
-  member x.RenderPart(name, model:obj) =  
-    if Razor.Resolve(name, model) = null then
-        let templateContent = RazorRender.Resolver.Resolve(name)
-        Razor.Compile(templateContent, model.GetType(), name)
-    Razor.Run(name, model)
+  member x.RenderPart(name, model:obj) = 
+    if x.TemplateService.Resolve(name, model) = null then
+        let templateContent = (x.TemplateService :?> MyTemplateService).Resolver.Resolve(name)
+        x.TemplateService.Compile(templateContent, model.GetType(), name)
+    x.TemplateService.Run(name, model, null)

--- a/src/FSharp.Formatting.CommandTool/FSharp.Formatting.CommandTool.fsproj
+++ b/src/FSharp.Formatting.CommandTool/FSharp.Formatting.CommandTool.fsproj
@@ -154,10 +154,19 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
       <ItemGroup>
         <Reference Include="RazorEngine">
           <HintPath>..\..\packages\RazorEngine\lib\net40\RazorEngine.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+      <ItemGroup>
+        <Reference Include="RazorEngine">
+          <HintPath>..\..\packages\RazorEngine\lib\net45\RazorEngine.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/src/FSharp.Formatting.CommandTool/FSharp.Formatting.CommandTool.fsproj
+++ b/src/FSharp.Formatting.CommandTool/FSharp.Formatting.CommandTool.fsproj
@@ -10,6 +10,7 @@
     <RootNamespace>FSharp.FormattingCLI</RootNamespace>
     <AssemblyName>fsformatting</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkIdentifier  Condition=" '$(TargetFrameworkIdentifier)' == ''">.NETFramework</TargetFrameworkIdentifier>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
     <Name>FSharp.FormattingCLI</Name>

--- a/src/FSharp.Literate/FSharp.Literate.fsproj
+++ b/src/FSharp.Literate/FSharp.Literate.fsproj
@@ -136,10 +136,19 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
       <ItemGroup>
         <Reference Include="RazorEngine">
           <HintPath>..\..\packages\RazorEngine\lib\net40\RazorEngine.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+      <ItemGroup>
+        <Reference Include="RazorEngine">
+          <HintPath>..\..\packages\RazorEngine\lib\net45\RazorEngine.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/src/FSharp.Literate/Formatting.fs
+++ b/src/FSharp.Literate/Formatting.fs
@@ -73,11 +73,11 @@ module Templating =
 
   /// Depending on the template file, use either Razor engine
   /// or simple Html engine with {replacements} to format the document
-  let private generateFile contentTag parameters templateOpt output layoutRoots =
+  let private generateFile references contentTag parameters templateOpt output layoutRoots =
     match templateOpt with
     | Some (file:string) when file.EndsWith("cshtml", true, CultureInfo.InvariantCulture) -> 
         let key = Array.ofSeq layoutRoots, file
-        let razor = razorCache.GetOrAdd(key, fun (layoutRoots, file) -> RazorRender(layoutRoots, [], Path.GetFileNameWithoutExtension file))
+        let razor = razorCache.GetOrAdd(key, fun (layoutRoots, file) -> RazorRender(layoutRoots, [], Path.GetFileNameWithoutExtension file, ?references = references))
         let props = [ "Properties", dict parameters ]
         let generated = razor.ProcessFile(props)
         File.WriteAllText(output, generated)      
@@ -89,7 +89,7 @@ module Templating =
   // Formate literate document
   // ------------------------------------------------------------------------------------
 
-  let processFile (doc:LiterateDocument) output ctx = 
+  let processFile references (doc:LiterateDocument) output ctx = 
 
     // If we want to include the source code of the script, then process
     // the entire source and generate replacement {source} => ...some html...
@@ -125,4 +125,4 @@ module Templating =
         "page-source", doc.SourceFile
         contentTag, formattedDocument
         "tooltips", tipsHtml ]
-    generateFile contentTag parameters ctx.TemplateFile output ctx.LayoutRoots
+    generateFile references contentTag parameters ctx.TemplateFile output ctx.LayoutRoots

--- a/src/FSharp.MetadataFormat/FSharp.MetadataFormat.fsproj
+++ b/src/FSharp.MetadataFormat/FSharp.MetadataFormat.fsproj
@@ -133,10 +133,19 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
       <ItemGroup>
         <Reference Include="RazorEngine">
           <HintPath>..\..\packages\RazorEngine\lib\net40\RazorEngine.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+      <ItemGroup>
+        <Reference Include="RazorEngine">
+          <HintPath>..\..\packages\RazorEngine\lib\net45\RazorEngine.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/src/FSharp.MetadataFormat/Main.fs
+++ b/src/FSharp.MetadataFormat/Main.fs
@@ -972,13 +972,13 @@ type Html private() =
 
 /// Exposes metadata formatting functionality
 type MetadataFormat = 
-  static member Generate(dllFile, outDir, layoutRoots, ?parameters, ?namespaceTemplate, ?moduleTemplate, ?typeTemplate, ?xmlFile, ?sourceRepo, ?sourceFolder, ?publicOnly, ?libDirs, ?otherFlags, ?markDownComments, ?urlRangeHighlight) =
+  static member Generate(dllFile, outDir, layoutRoots, ?parameters, ?namespaceTemplate, ?moduleTemplate, ?typeTemplate, ?xmlFile, ?sourceRepo, ?sourceFolder, ?publicOnly, ?libDirs, ?otherFlags, ?markDownComments, ?urlRangeHighlight, ?assemblyReferences) =
     MetadataFormat.Generate
       ( [dllFile], outDir, layoutRoots, ?parameters = parameters, ?namespaceTemplate = namespaceTemplate, 
         ?moduleTemplate = moduleTemplate, ?typeTemplate = typeTemplate, ?xmlFile = xmlFile, ?sourceRepo = sourceRepo, ?sourceFolder = sourceFolder,
-        ?publicOnly = publicOnly, ?libDirs = libDirs, ?otherFlags = otherFlags, ?markDownComments = markDownComments, ?urlRangeHighlight = urlRangeHighlight)
+        ?publicOnly = publicOnly, ?libDirs = libDirs, ?otherFlags = otherFlags, ?markDownComments = markDownComments, ?urlRangeHighlight = urlRangeHighlight, ?assemblyReferences = assemblyReferences)
 
-  static member Generate(dllFiles, outDir, layoutRoots, ?parameters, ?namespaceTemplate, ?moduleTemplate, ?typeTemplate, ?xmlFile, ?sourceRepo, ?sourceFolder, ?publicOnly, ?libDirs, ?otherFlags, ?markDownComments, ?urlRangeHighlight) =
+  static member Generate(dllFiles, outDir, layoutRoots, ?parameters, ?namespaceTemplate, ?moduleTemplate, ?typeTemplate, ?xmlFile, ?sourceRepo, ?sourceFolder, ?publicOnly, ?libDirs, ?otherFlags, ?markDownComments, ?urlRangeHighlight, ?assemblyReferences) =
     let (@@) a b = Path.Combine(a, b)
     let parameters = defaultArg parameters []
     let props = [ "Properties", dict parameters ]
@@ -1106,7 +1106,7 @@ type MetadataFormat =
         
     // Generate all the HTML stuff
     Log.logf "Starting razor engine"
-    let razor = RazorRender<AssemblyGroup>(layoutRoots, ["FSharp.MetadataFormat"], namespaceTemplate)
+    let razor = RazorRender<AssemblyGroup>(layoutRoots, ["FSharp.MetadataFormat"], namespaceTemplate, ?references = assemblyReferences)
 
     Log.logf "Generating: index.html"
     let out = razor.ProcessFile(asm, props)
@@ -1121,7 +1121,7 @@ type MetadataFormat =
       [ for ns in asm.Namespaces do 
           for n in ns.Modules do yield! nestedModules n ]
     
-    let razor = RazorRender<ModuleInfo>(layoutRoots, ["FSharp.MetadataFormat"], moduleTemplate)
+    let razor = RazorRender<ModuleInfo>(layoutRoots, ["FSharp.MetadataFormat"], moduleTemplate, ?references = assemblyReferences)
 
     for modul in modules do
       Log.logf "Generating module: %s" modul.UrlName
@@ -1139,7 +1139,7 @@ type MetadataFormat =
           yield! ns.Types ]
 
     // Generate documentation for all types
-    let razor = new RazorRender<TypeInfo>(layoutRoots, ["FSharp.MetadataFormat"], typeTemplate)
+    let razor = new RazorRender<TypeInfo>(layoutRoots, ["FSharp.MetadataFormat"], typeTemplate, ?references = assemblyReferences)
     for typ in types do
       Log.logf "Generating type: %s" typ.UrlName
       let out = razor.ProcessFile(TypeInfo.Create(typ, asm), props)

--- a/tests/FSharp.Literate.Tests/FSharp.Literate.Tests.fsproj
+++ b/tests/FSharp.Literate.Tests/FSharp.Literate.Tests.fsproj
@@ -117,10 +117,19 @@
     </Reference>
   </ItemGroup>
   <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
       <ItemGroup>
         <Reference Include="RazorEngine">
           <HintPath>..\..\packages\RazorEngine\lib\net40\RazorEngine.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+      <ItemGroup>
+        <Reference Include="RazorEngine">
+          <HintPath>..\..\packages\RazorEngine\lib\net45\RazorEngine.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/tests/FSharp.MetadataFormat.Tests/FSharp.MetadataFormat.Tests.fsproj
+++ b/tests/FSharp.MetadataFormat.Tests/FSharp.MetadataFormat.Tests.fsproj
@@ -117,10 +117,19 @@
     </Reference>
   </ItemGroup>
   <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
       <ItemGroup>
         <Reference Include="RazorEngine">
           <HintPath>..\..\packages\RazorEngine\lib\net40\RazorEngine.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+      <ItemGroup>
+        <Reference Include="RazorEngine">
+          <HintPath>..\..\packages\RazorEngine\lib\net45\RazorEngine.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/tests/FSharp.MetadataFormat.Tests/files/FsLib/FsLib1.fsproj
+++ b/tests/FSharp.MetadataFormat.Tests/files/FsLib/FsLib1.fsproj
@@ -100,10 +100,19 @@
     </Reference>
   </ItemGroup>
   <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
       <ItemGroup>
         <Reference Include="RazorEngine">
           <HintPath>..\..\..\..\packages\RazorEngine\lib\net40\RazorEngine.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+      <ItemGroup>
+        <Reference Include="RazorEngine">
+          <HintPath>..\..\..\..\packages\RazorEngine\lib\net45\RazorEngine.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/tests/FSharp.MetadataFormat.Tests/files/FsLib/FsLib1.fsproj
+++ b/tests/FSharp.MetadataFormat.Tests/files/FsLib/FsLib1.fsproj
@@ -8,8 +8,8 @@
     <OutputType>Library</OutputType>
     <RootNamespace>FsLib</RootNamespace>
     <AssemblyName>FsLib1</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
     <Name>FsLib1</Name>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/FSharp.MetadataFormat.Tests/files/FsLib/FsLib2.fsproj
+++ b/tests/FSharp.MetadataFormat.Tests/files/FsLib/FsLib2.fsproj
@@ -8,8 +8,8 @@
     <OutputType>Library</OutputType>
     <RootNamespace>FsLib</RootNamespace>
     <AssemblyName>FsLib2</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
     <Name>FsLib1</Name>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/FSharp.MetadataFormat.Tests/files/FsLib/FsLib2.fsproj
+++ b/tests/FSharp.MetadataFormat.Tests/files/FsLib/FsLib2.fsproj
@@ -99,10 +99,19 @@
     </Reference>
   </ItemGroup>
   <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
       <ItemGroup>
         <Reference Include="RazorEngine">
           <HintPath>..\..\..\..\packages\RazorEngine\lib\net40\RazorEngine.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+      <ItemGroup>
+        <Reference Include="RazorEngine">
+          <HintPath>..\..\..\..\packages\RazorEngine\lib\net45\RazorEngine.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/tests/FSharp.MetadataFormat.Tests/files/TestLib/TestLib1.fsproj
+++ b/tests/FSharp.MetadataFormat.Tests/files/TestLib/TestLib1.fsproj
@@ -8,8 +8,8 @@
     <OutputType>Library</OutputType>
     <RootNamespace>TestLib</RootNamespace>
     <AssemblyName>TestLib1</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
     <Name>TestLib1</Name>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/FSharp.MetadataFormat.Tests/files/TestLib/TestLib1.fsproj
+++ b/tests/FSharp.MetadataFormat.Tests/files/TestLib/TestLib1.fsproj
@@ -100,10 +100,19 @@
     </Reference>
   </ItemGroup>
   <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
       <ItemGroup>
         <Reference Include="RazorEngine">
           <HintPath>..\..\..\..\packages\RazorEngine\lib\net40\RazorEngine.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+      <ItemGroup>
+        <Reference Include="RazorEngine">
+          <HintPath>..\..\..\..\packages\RazorEngine\lib\net45\RazorEngine.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/tests/FSharp.MetadataFormat.Tests/files/TestLib/TestLib2.fsproj
+++ b/tests/FSharp.MetadataFormat.Tests/files/TestLib/TestLib2.fsproj
@@ -100,10 +100,19 @@
     </Reference>
   </ItemGroup>
   <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
       <ItemGroup>
         <Reference Include="RazorEngine">
           <HintPath>..\..\..\..\packages\RazorEngine\lib\net40\RazorEngine.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+      <ItemGroup>
+        <Reference Include="RazorEngine">
+          <HintPath>..\..\..\..\packages\RazorEngine\lib\net45\RazorEngine.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/tests/FSharp.MetadataFormat.Tests/files/TestLib/TestLib2.fsproj
+++ b/tests/FSharp.MetadataFormat.Tests/files/TestLib/TestLib2.fsproj
@@ -8,8 +8,8 @@
     <OutputType>Library</OutputType>
     <RootNamespace>TestLib</RootNamespace>
     <AssemblyName>TestLib2</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
     <Name>TestLib1</Name>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/FSharp.MetadataFormat.Tests/files/crefLib/crefLib1.fsproj
+++ b/tests/FSharp.MetadataFormat.Tests/files/crefLib/crefLib1.fsproj
@@ -8,8 +8,8 @@
     <OutputType>Library</OutputType>
     <RootNamespace>crefLib1</RootNamespace>
     <AssemblyName>crefLib1</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
     <Name>crefLib1</Name>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/FSharp.MetadataFormat.Tests/files/crefLib/crefLib1.fsproj
+++ b/tests/FSharp.MetadataFormat.Tests/files/crefLib/crefLib1.fsproj
@@ -99,10 +99,19 @@
     </Reference>
   </ItemGroup>
   <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
       <ItemGroup>
         <Reference Include="RazorEngine">
           <HintPath>..\..\..\..\packages\RazorEngine\lib\net40\RazorEngine.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+      <ItemGroup>
+        <Reference Include="RazorEngine">
+          <HintPath>..\..\..\..\packages\RazorEngine\lib\net45\RazorEngine.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/tests/FSharp.MetadataFormat.Tests/files/crefLib/crefLib2.fsproj
+++ b/tests/FSharp.MetadataFormat.Tests/files/crefLib/crefLib2.fsproj
@@ -9,8 +9,8 @@
     <OutputType>Library</OutputType>
     <RootNamespace>crefLib2</RootNamespace>
     <AssemblyName>crefLib2</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
     <Name>crefLib2</Name>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/FSharp.MetadataFormat.Tests/files/crefLib/crefLib2.fsproj
+++ b/tests/FSharp.MetadataFormat.Tests/files/crefLib/crefLib2.fsproj
@@ -107,10 +107,19 @@
     </Reference>
   </ItemGroup>
   <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
       <ItemGroup>
         <Reference Include="RazorEngine">
           <HintPath>..\..\..\..\packages\RazorEngine\lib\net40\RazorEngine.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+      <ItemGroup>
+        <Reference Include="RazorEngine">
+          <HintPath>..\..\..\..\packages\RazorEngine\lib\net45\RazorEngine.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/tests/FSharp.MetadataFormat.Tests/files/crefLib/crefLib3.csproj
+++ b/tests/FSharp.MetadataFormat.Tests/files/crefLib/crefLib3.csproj
@@ -90,10 +90,19 @@
     </Reference>
   </ItemGroup>
   <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
       <ItemGroup>
         <Reference Include="RazorEngine">
           <HintPath>..\..\..\..\packages\RazorEngine\lib\net40\RazorEngine.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+      <ItemGroup>
+        <Reference Include="RazorEngine">
+          <HintPath>..\..\..\..\packages\RazorEngine\lib\net45\RazorEngine.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/tests/FSharp.MetadataFormat.Tests/files/crefLib/crefLib3.csproj
+++ b/tests/FSharp.MetadataFormat.Tests/files/crefLib/crefLib3.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>crefLib3</RootNamespace>
     <AssemblyName>crefLib3</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/FSharp.MetadataFormat.Tests/files/crefLib/crefLib4.csproj
+++ b/tests/FSharp.MetadataFormat.Tests/files/crefLib/crefLib4.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>crefLib4</RootNamespace>
     <AssemblyName>crefLib4</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/FSharp.MetadataFormat.Tests/files/crefLib/crefLib4.csproj
+++ b/tests/FSharp.MetadataFormat.Tests/files/crefLib/crefLib4.csproj
@@ -104,10 +104,19 @@
     </Reference>
   </ItemGroup>
   <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
       <ItemGroup>
         <Reference Include="RazorEngine">
           <HintPath>..\..\..\..\packages\RazorEngine\lib\net40\RazorEngine.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+      <ItemGroup>
+        <Reference Include="RazorEngine">
+          <HintPath>..\..\..\..\packages\RazorEngine\lib\net45\RazorEngine.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>


### PR DESCRIPTION
This reverts commit 1289f612a8d34279add6cffbcdf5eaa1d14c05e4 and updates RazorEngine to version 3.5.0-beta2 (paket doesnt like beta1).
The problem with the previous commit was that upstream projects broke (because of a different dependency).
This time we use the official update of the RazorEngine project.

@forki: I again have a problem with paket. With this change `paket install` will not work:

    Paket failed with:

    Error in resolution.
      Resolved:
        - FAKE 3.12.2
        - RazorEngine 3.5.0-beta2
        - NuGet.CommandLine 2.8.3
        - NUnit 2.6.4
        - NUnit.Runners 2.6.4
        - Microsoft.AspNet.Razor 2.0.30506.0
        - CommandLineParser 1.9.71
        - FSharp.Compiler.Service 0.0.67
      Can't resolve:
        - Microsoft.AspNet.Razor >= 3.0.0
           - from RazorEngine 3.5.0-beta2
     Please try to relax some conditions.

`paket update` worked fine and everything seems to be ok within the project files. Any hint would be very welcome, can we ignore this?
Another thing I noticed: paket seems to add dependencies to the FsLib project files while they do not have any paket.references and they dont need them.

Happy New Year to all who read this :)