### PR TITLE
transform code blocks in list correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tests/Benchmarks/testfiles/*/*.html
 .paket/paket.exe
 release.cmd
 *.orig
+*NCrunch*

--- a/tests/FSharp.Markdown.Tests/Markdown.fs
+++ b/tests/FSharp.Markdown.Tests/Markdown.fs
@@ -197,6 +197,13 @@ let ``Transform code spans correctly``() =
     let expected = "<p>HTML contains the <code>&lt;blink&gt;</code> tag</p>\r\n" |> properNewLines;
     Markdown.TransformHtml doc
     |> shouldEqual expected
+
+[<Test>]
+let ``Transform code blocks in list correctly``() =
+    let doc = "- code sample:\r\n\r\n    let x = 1\r\n";
+    let expected = "<ul>\r\n<li><p>code sample:</p></li>\r\n</ul>\r\n\r\n<pre><code>let x = 1\r\n</code></pre>\r\n" |> properNewLines;
+    Markdown.TransformHtml doc
+    |> shouldEqual expected
     
 [<Test>]
 let ``Transform display math correctly``() =


### PR DESCRIPTION
In FsReveal we often have codeblocks below a list with bullet points.

    ### paket.dependencies
    
    - specifies rules regarding your application's dependencies:
    
        source https://nuget.org/api/v2
        
        nuget Castle.Windsor-log4net ~> 3.2
        nuget NUnit

Result with current FSharp.Formatting:

![image](https://cloud.githubusercontent.com/assets/57396/5616189/47c60e5c-9502-11e4-96b8-519248b68144.png)

this PR tries to fix this.