### PR TITLE
Github flavored markdown code-blocks.

### DIFF
--- a/src/FSharp.Literate/Evaluator.fs
+++ b/src/FSharp.Literate/Evaluator.fs
@@ -128,7 +128,7 @@ type FsiEvaluator(?options:string[]) =
   /// Registered transformations for pretty printing values
   /// (the default formats value as a string and emits single CodeBlock)
   let mutable valueTransformations = 
-    [ (fun (o:obj, t:Type) ->Some([CodeBlock(sprintf "%A" o)]) ) ]
+    [ (fun (o:obj, t:Type) ->Some([CodeBlock (CodeBlockInfo.Create (sprintf "%A" o))]) ) ]
 
   /// Register a function that formats (some) values that are produced by the evaluator.
   /// The specified function should return 'Some' when it knows how to format a value
@@ -147,12 +147,12 @@ type FsiEvaluator(?options:string[]) =
       match result :?> FsiEvaluationResult, kind with
       | result, FsiEmbedKind.Output -> 
           let s = defaultArg result.Output "No output has been produced."
-          [ CodeBlock(s.Trim()) ]
+          [ CodeBlock(CodeBlockInfo.Create (s.Trim())) ]
       | { ItValue = Some v }, FsiEmbedKind.ItValue
       | { Result = Some v }, FsiEmbedKind.Value ->
           valueTransformations |> Seq.pick (fun f -> lock lockObj (fun () -> f v))
-      | _, FsiEmbedKind.ItValue -> [ CodeBlock "No value has been returned" ]
-      | _, FsiEmbedKind.Value -> [ CodeBlock "No value has been returned" ]
+      | _, FsiEmbedKind.ItValue -> [ CodeBlock (CodeBlockInfo.Create "No value has been returned") ]
+      | _, FsiEmbedKind.Value -> [ CodeBlock (CodeBlockInfo.Create "No value has been returned") ]
 
     /// Evaluates the given text in an fsi session and returns
     /// an FsiEvaluationResult.

--- a/src/FSharp.Literate/Evaluator.fs
+++ b/src/FSharp.Literate/Evaluator.fs
@@ -128,7 +128,7 @@ type FsiEvaluator(?options:string[]) =
   /// Registered transformations for pretty printing values
   /// (the default formats value as a string and emits single CodeBlock)
   let mutable valueTransformations = 
-    [ (fun (o:obj, t:Type) ->Some([CodeBlock (CodeBlockInfo.Create (sprintf "%A" o))]) ) ]
+    [ (fun (o:obj, t:Type) ->Some([CodeBlock (sprintf "%A" o, "", "")]) ) ]
 
   /// Register a function that formats (some) values that are produced by the evaluator.
   /// The specified function should return 'Some' when it knows how to format a value
@@ -147,12 +147,12 @@ type FsiEvaluator(?options:string[]) =
       match result :?> FsiEvaluationResult, kind with
       | result, FsiEmbedKind.Output -> 
           let s = defaultArg result.Output "No output has been produced."
-          [ CodeBlock(CodeBlockInfo.Create (s.Trim())) ]
+          [ CodeBlock(s.Trim(), "", "") ]
       | { ItValue = Some v }, FsiEmbedKind.ItValue
       | { Result = Some v }, FsiEmbedKind.Value ->
           valueTransformations |> Seq.pick (fun f -> lock lockObj (fun () -> f v))
-      | _, FsiEmbedKind.ItValue -> [ CodeBlock (CodeBlockInfo.Create "No value has been returned") ]
-      | _, FsiEmbedKind.Value -> [ CodeBlock (CodeBlockInfo.Create "No value has been returned") ]
+      | _, FsiEmbedKind.ItValue -> [ CodeBlock ("No value has been returned", "", "") ]
+      | _, FsiEmbedKind.Value -> [ CodeBlock ("No value has been returned", "", "") ]
 
     /// Evaluates the given text in an fsi session and returns
     /// an FsiEvaluationResult.

--- a/src/FSharp.Literate/Formatting.fs
+++ b/src/FSharp.Literate/Formatting.fs
@@ -35,7 +35,7 @@ module internal Formatting =
   let getSourceDocument (doc:LiterateDocument) =
     match doc.Source with
     | LiterateSource.Markdown text ->
-        doc.With(paragraphs = [CodeBlock (CodeBlockInfo.Create text)])
+        doc.With(paragraphs = [CodeBlock (text, "", "")])
     | LiterateSource.Script snippets ->
         let paragraphs = 
           [ for Snippet(name, lines) in snippets do

--- a/src/FSharp.Literate/Formatting.fs
+++ b/src/FSharp.Literate/Formatting.fs
@@ -35,7 +35,7 @@ module internal Formatting =
   let getSourceDocument (doc:LiterateDocument) =
     match doc.Source with
     | LiterateSource.Markdown text ->
-        doc.With(paragraphs = [CodeBlock text])
+        doc.With(paragraphs = [CodeBlock (CodeBlockInfo.Create text)])
     | LiterateSource.Script snippets ->
         let paragraphs = 
           [ for Snippet(name, lines) in snippets do

--- a/src/FSharp.Literate/Transformations.fs
+++ b/src/FSharp.Literate/Transformations.fs
@@ -20,10 +20,10 @@ module internal Transformations =
   /// to colorize. We skip snippets that specify non-fsharp langauge e.g. [lang=csharp].
   let rec collectCodeSnippets par = seq {
     match par with
-    | CodeBlock({ Code = (String.StartsWithWrapped ("[", "]") (ParseCommands cmds, String.TrimStart code)); CodeLanguage = language }) 
-        when (language.IsSome && language.Value <> "fsharp") || (cmds.ContainsKey("lang") && cmds.["lang"] <> "fsharp") -> ()
-    | CodeBlock({ Code = (String.StartsWithWrapped ("[", "]") (ParseCommands cmds, String.TrimStart code)) }) 
-    | CodeBlock(Let (dict []) (cmds, { Code = code })) ->
+    | CodeBlock((String.StartsWithWrapped ("[", "]") (ParseCommands cmds, String.TrimStart code)), language, _) 
+        when (not (String.IsNullOrWhiteSpace(language)) && language <> "fsharp") || (cmds.ContainsKey("lang") && cmds.["lang"] <> "fsharp") -> ()
+    | CodeBlock((String.StartsWithWrapped ("[", "]") (ParseCommands cmds, String.TrimStart code)), _, _) 
+    | CodeBlock(Let (dict []) (cmds, code), _, _) ->
         let modul = 
           match cmds.TryGetValue("module") with
           | true, v -> Some v | _ -> None
@@ -38,8 +38,8 @@ module internal Transformations =
   /// Replace CodeBlock elements with formatted HTML that was processed by the F# snippets tool
   /// (The dictionary argument is a map from original code snippets to formatted HTML snippets.)
   let rec replaceCodeSnippets path (codeLookup:IDictionary<_, _>) = function
-    | CodeBlock { Code = (String.StartsWithWrapped ("[", "]") (ParseCommands cmds, code)); CodeLanguage = language } 
-    | CodeBlock(Let (dict []) (cmds, { Code = code; CodeLanguage = language })) ->
+    | CodeBlock ((String.StartsWithWrapped ("[", "]") (ParseCommands cmds, code)), language, _) 
+    | CodeBlock(Let (dict []) (cmds, code), language, _) ->
         let code = 
             if code.StartsWith("\r\n") then code.Substring(2)
             elif code.StartsWith("\n") then code.Substring(1)
@@ -59,11 +59,10 @@ module internal Transformations =
           else code
         let lang = 
           match language with
-          | Some language -> Some language
-          | None when cmds.ContainsKey("lang") -> Some cmds.["lang"]
-          | _ -> None
-        if (lang.IsSome) && lang.Value <> "fsharp" then 
-          Some (EmbedParagraphs(LanguageTaggedCode(lang.Value, code)))
+          | String.WhiteSpace when cmds.ContainsKey("lang") -> cmds.["lang"]
+          | language -> language
+        if not (String.IsNullOrWhiteSpace(lang)) && lang <> "fsharp" then 
+          Some (EmbedParagraphs(LanguageTaggedCode(lang, code)))
         else
           Some (EmbedParagraphs(FormattedCode(codeLookup.[code])))
 
@@ -274,7 +273,7 @@ module internal Transformations =
           | _ -> None
         match special with 
         | EvalFormat(Some result, _, kind) -> ctx.Evaluator.Value.Format(result, kind)
-        | EvalFormat(None, ref, _) -> [ CodeBlock(CodeBlockInfo.Create ("Could not find reference '" + ref + "'")) ]
+        | EvalFormat(None, ref, _) -> [ CodeBlock("Could not find reference '" + ref + "'", "", "") ]
         | other -> [ EmbedParagraphs(other) ]
 
     // Traverse all other structrues recursively

--- a/src/FSharp.Literate/Transformations.fs
+++ b/src/FSharp.Literate/Transformations.fs
@@ -40,6 +40,10 @@ module internal Transformations =
   let rec replaceCodeSnippets path (codeLookup:IDictionary<_, _>) = function
     | CodeBlock(String.StartsWithWrapped ("[", "]") (ParseCommands cmds, code)) 
     | CodeBlock(Let (dict []) (cmds, code)) ->
+        let code = 
+            if code.StartsWith("\r\n") then code.Substring(2)
+            elif code.StartsWith("\n") then code.Substring(1)
+            else code
         if cmds.ContainsKey("hide") then None else
         let code = 
           if cmds.ContainsKey("file") && cmds.ContainsKey("key") then 

--- a/src/FSharp.Literate/Transformations.fs
+++ b/src/FSharp.Literate/Transformations.fs
@@ -38,7 +38,7 @@ module internal Transformations =
   /// Replace CodeBlock elements with formatted HTML that was processed by the F# snippets tool
   /// (The dictionary argument is a map from original code snippets to formatted HTML snippets.)
   let rec replaceCodeSnippets path (codeLookup:IDictionary<_, _>) = function
-    | CodeBlock(String.StartsWithWrapped ("[", "]") (ParseCommands cmds, String.TrimStart code)) 
+    | CodeBlock(String.StartsWithWrapped ("[", "]") (ParseCommands cmds, code)) 
     | CodeBlock(Let (dict []) (cmds, code)) ->
         if cmds.ContainsKey("hide") then None else
         let code = 

--- a/src/FSharp.Markdown/HtmlFormatting.fs
+++ b/src/FSharp.Markdown/HtmlFormatting.fs
@@ -182,16 +182,16 @@ let rec formatParagraph (ctx:FormattingContext) paragraph =
       ctx.Writer.Write("</p>")
   | HorizontalRule(_) ->
       ctx.Writer.Write("<hr />")
-  | CodeBlock({ Code = code; CodeLanguage = Some codeLanguage }) ->
+  | CodeBlock(code, String.WhiteSpace, _) ->
       if ctx.WrapCodeSnippets then ctx.Writer.Write("<table class=\"pre\"><tr><td>")
-      let langCode = sprintf "language-%s" codeLanguage
-      ctx.Writer.Write(sprintf "<pre class=\"line-numbers %s\"><code class=\"%s\">" langCode langCode)
+      ctx.Writer.Write("<pre><code>")
       ctx.Writer.Write(htmlEncode code)
       ctx.Writer.Write("</code></pre>")
       if ctx.WrapCodeSnippets then ctx.Writer.Write("</td></tr></table>")
-  | CodeBlock({ Code = code }) ->
+  | CodeBlock(code, codeLanguage, _) ->
       if ctx.WrapCodeSnippets then ctx.Writer.Write("<table class=\"pre\"><tr><td>")
-      ctx.Writer.Write("<pre><code>")
+      let langCode = sprintf "language-%s" codeLanguage
+      ctx.Writer.Write(sprintf "<pre class=\"line-numbers %s\"><code class=\"%s\">" langCode langCode)
       ctx.Writer.Write(htmlEncode code)
       ctx.Writer.Write("</code></pre>")
       if ctx.WrapCodeSnippets then ctx.Writer.Write("</td></tr></table>")

--- a/src/FSharp.Markdown/HtmlFormatting.fs
+++ b/src/FSharp.Markdown/HtmlFormatting.fs
@@ -188,14 +188,12 @@ let rec formatParagraph (ctx:FormattingContext) paragraph =
       let langCode = sprintf "language-%s" cmds.["lang"]
       ctx.Writer.Write(sprintf "<pre class=\"line-numbers %s\"><code class=\"%s\">" langCode langCode)
       ctx.Writer.Write(htmlEncode code)
-      ctx.Writer.Write(ctx.Newline)
       ctx.Writer.Write("</code></pre>")
       if ctx.WrapCodeSnippets then ctx.Writer.Write("</td></tr></table>")
   | CodeBlock(code) ->
       if ctx.WrapCodeSnippets then ctx.Writer.Write("<table class=\"pre\"><tr><td>")
       ctx.Writer.Write("<pre><code>")
       ctx.Writer.Write(htmlEncode code)
-      ctx.Writer.Write(ctx.Newline)
       ctx.Writer.Write("</code></pre>")
       if ctx.WrapCodeSnippets then ctx.Writer.Write("</td></tr></table>")
   | TableBlock(headers, alignments, rows) ->

--- a/src/FSharp.Markdown/HtmlFormatting.fs
+++ b/src/FSharp.Markdown/HtmlFormatting.fs
@@ -182,15 +182,14 @@ let rec formatParagraph (ctx:FormattingContext) paragraph =
       ctx.Writer.Write("</p>")
   | HorizontalRule(_) ->
       ctx.Writer.Write("<hr />")
-  | CodeBlock(String.StartsWithWrapped ("[", "]") (ParseCommands cmds, String.TrimStart code)) 
-    when cmds.ContainsKey("lang") ->
+  | CodeBlock({ Code = code; CodeLanguage = Some codeLanguage }) ->
       if ctx.WrapCodeSnippets then ctx.Writer.Write("<table class=\"pre\"><tr><td>")
-      let langCode = sprintf "language-%s" cmds.["lang"]
+      let langCode = sprintf "language-%s" codeLanguage
       ctx.Writer.Write(sprintf "<pre class=\"line-numbers %s\"><code class=\"%s\">" langCode langCode)
       ctx.Writer.Write(htmlEncode code)
       ctx.Writer.Write("</code></pre>")
       if ctx.WrapCodeSnippets then ctx.Writer.Write("</td></tr></table>")
-  | CodeBlock(code) ->
+  | CodeBlock({ Code = code }) ->
       if ctx.WrapCodeSnippets then ctx.Writer.Write("<table class=\"pre\"><tr><td>")
       ctx.Writer.Write("<pre><code>")
       ctx.Writer.Write(htmlEncode code)

--- a/src/FSharp.Markdown/HtmlFormatting.fs
+++ b/src/FSharp.Markdown/HtmlFormatting.fs
@@ -182,6 +182,15 @@ let rec formatParagraph (ctx:FormattingContext) paragraph =
       ctx.Writer.Write("</p>")
   | HorizontalRule(_) ->
       ctx.Writer.Write("<hr />")
+  | CodeBlock(String.StartsWithWrapped ("[", "]") (ParseCommands cmds, String.TrimStart code)) 
+    when cmds.ContainsKey("lang") ->
+      if ctx.WrapCodeSnippets then ctx.Writer.Write("<table class=\"pre\"><tr><td>")
+      let langCode = sprintf "language-%s" cmds.["lang"]
+      ctx.Writer.Write(sprintf "<pre class=\"line-numbers %s\"><code class=\"%s\">" langCode langCode)
+      ctx.Writer.Write(htmlEncode code)
+      ctx.Writer.Write(ctx.Newline)
+      ctx.Writer.Write("</code></pre>")
+      if ctx.WrapCodeSnippets then ctx.Writer.Write("</td></tr></table>")
   | CodeBlock(code) ->
       if ctx.WrapCodeSnippets then ctx.Writer.Write("<table class=\"pre\"><tr><td>")
       ctx.Writer.Write("<pre><code>")

--- a/src/FSharp.Markdown/LatexFormatting.fs
+++ b/src/FSharp.Markdown/LatexFormatting.fs
@@ -142,7 +142,7 @@ let rec formatParagraph (ctx:FormattingContext) paragraph =
       ctx.Writer.Write(@"\noindent\makebox[\linewidth]{\rule{\linewidth}{0.4pt}}\medskip")
       ctx.LineBreak()
 
-  | CodeBlock(code) ->
+  | CodeBlock({ Code = code }) ->
       ctx.Writer.Write(@"\begin{lstlisting}")
       ctx.LineBreak()
       ctx.Writer.Write(code)

--- a/src/FSharp.Markdown/LatexFormatting.fs
+++ b/src/FSharp.Markdown/LatexFormatting.fs
@@ -142,7 +142,7 @@ let rec formatParagraph (ctx:FormattingContext) paragraph =
       ctx.Writer.Write(@"\noindent\makebox[\linewidth]{\rule{\linewidth}{0.4pt}}\medskip")
       ctx.LineBreak()
 
-  | CodeBlock({ Code = code }) ->
+  | CodeBlock(code, _, _) ->
       ctx.Writer.Write(@"\begin{lstlisting}")
       ctx.LineBreak()
       ctx.Writer.Write(code)

--- a/src/FSharp.Markdown/Markdown.fs
+++ b/src/FSharp.Markdown/Markdown.fs
@@ -42,16 +42,11 @@ and MarkdownSpans = list<MarkdownSpan>
 
 and MarkdownEmbedSpans =
   abstract Render : unit -> MarkdownSpans
-type CodeBlockInfo =
-  { Code : string
-    CodeLanguage : string option
-    IgnoredLine : string option }
-  static member Create(code, ?language, ?ignored) = 
-    { Code = code; CodeLanguage = language; IgnoredLine = ignored }
+
 type MarkdownParagraph = 
   | Heading of int * MarkdownSpans
   | Paragraph of MarkdownSpans
-  | CodeBlock of CodeBlockInfo
+  | CodeBlock of string * string * string
   | InlineBlock of string
   | ListBlock of MarkdownListKind * list<MarkdownParagraphs>
   | QuotedBlock of MarkdownParagraphs

--- a/src/FSharp.Markdown/Markdown.fs
+++ b/src/FSharp.Markdown/Markdown.fs
@@ -42,11 +42,16 @@ and MarkdownSpans = list<MarkdownSpan>
 
 and MarkdownEmbedSpans =
   abstract Render : unit -> MarkdownSpans
-
+type CodeBlockInfo =
+  { Code : string
+    CodeLanguage : string option
+    IgnoredLine : string option }
+  static member Create(code, ?language, ?ignored) = 
+    { Code = code; CodeLanguage = language; IgnoredLine = ignored }
 type MarkdownParagraph = 
   | Heading of int * MarkdownSpans
   | Paragraph of MarkdownSpans
-  | CodeBlock of string
+  | CodeBlock of CodeBlockInfo
   | InlineBlock of string
   | ListBlock of MarkdownListKind * list<MarkdownParagraphs>
   | QuotedBlock of MarkdownParagraphs

--- a/src/FSharp.Markdown/MarkdownParser.fs
+++ b/src/FSharp.Markdown/MarkdownParser.fs
@@ -291,6 +291,15 @@ let (|CodeBlock|_|) = function
             elif l.Length > 4 then l.Substring(4, l.Length - 4) 
             else l ]
       Some(code, rest)
+  | String.StartsWithTrim "```" header :: lines -> 
+      let code, rest = lines |> List.partitionUntil (fun line -> line.Contains "```")
+      let rest =
+        match rest with
+        | hd :: tl -> tl
+        | _ -> rest
+      Some (
+        (if String.IsNullOrWhiteSpace header then code else sprintf "[lang=%s]" header::code), 
+        rest)
   | _ -> None
 
 /// Matches when the input starts with a number. Returns the

--- a/tests/FSharp.Literate.Tests/EvalTests.fs
+++ b/tests/FSharp.Literate.Tests/EvalTests.fs
@@ -56,11 +56,11 @@ printf ">>%d<<" 12343
 
   // Contains transformed output
   doc.Paragraphs |> shouldMatchPar (function
-    | CodeBlock "42" -> true | _ -> false)
+    | CodeBlock { Code = "42" } -> true | _ -> false)
   doc.Paragraphs |> shouldMatchPar (function
-    | CodeBlock "85" -> true | _ -> false)
+    | CodeBlock { Code = "85" } -> true | _ -> false)
   doc.Paragraphs |> shouldMatchPar (function
-    | CodeBlock ">>12343<<" -> true | _ -> false)
+    | CodeBlock { Code = ">>12343<<" } -> true | _ -> false)
 
 [<Test; Ignore>]
 let ``Can evaluate hidden code snippets`` () =

--- a/tests/FSharp.Literate.Tests/EvalTests.fs
+++ b/tests/FSharp.Literate.Tests/EvalTests.fs
@@ -56,11 +56,11 @@ printf ">>%d<<" 12343
 
   // Contains transformed output
   doc.Paragraphs |> shouldMatchPar (function
-    | CodeBlock { Code = "42" } -> true | _ -> false)
+    | CodeBlock ("42", _, _) -> true | _ -> false)
   doc.Paragraphs |> shouldMatchPar (function
-    | CodeBlock { Code = "85" } -> true | _ -> false)
+    | CodeBlock ("85", _, _) -> true | _ -> false)
   doc.Paragraphs |> shouldMatchPar (function
-    | CodeBlock { Code = ">>12343<<" } -> true | _ -> false)
+    | CodeBlock (">>12343<<", _, _) -> true | _ -> false)
 
 [<Test; Ignore>]
 let ``Can evaluate hidden code snippets`` () =

--- a/tests/FSharp.Literate.Tests/Tests.fs
+++ b/tests/FSharp.Literate.Tests/Tests.fs
@@ -115,6 +115,13 @@ hello
   let html = Literate.WriteHtml(doc)
   html |> should contain "<span class=\"k\">var</span>"
 
+[<Test>]
+let ``Codeblock whitespace is preserved`` () =
+  let doc = "```markup\r\n    test\r\n    blub\r\n```\r\n";
+  let expected = "<table class=\"pre\"><tr><td><pre lang=\"markup\">\r\n    test\r\n    blub\r\n</pre></td></tr></table>\r\n";
+  let doc = Literate.ParseMarkdownString(doc, formatAgent=getFormatAgent())
+  let html = Literate.WriteHtml(doc)
+  html |> should contain expected
 
 // --------------------------------------------------------------------------------------
 // Test that parsed documents for Markdown and F# #scripts are the same

--- a/tests/FSharp.Literate.Tests/Tests.fs
+++ b/tests/FSharp.Literate.Tests/Tests.fs
@@ -118,7 +118,7 @@ hello
 [<Test>]
 let ``Codeblock whitespace is preserved`` () =
   let doc = "```markup\r\n    test\r\n    blub\r\n```\r\n";
-  let expected = "<table class=\"pre\"><tr><td><pre lang=\"markup\">\r\n    test\r\n    blub\r\n</pre></td></tr></table>\r\n";
+  let expected = "<table class=\"pre\"><tr><td><pre lang=\"markup\">    test\r\n    blub\r\n</pre></td></tr></table>\r\n";
   let doc = Literate.ParseMarkdownString(doc, formatAgent=getFormatAgent())
   let html = Literate.WriteHtml(doc)
   html |> should contain expected

--- a/tests/FSharp.Literate.Tests/Tests.fs
+++ b/tests/FSharp.Literate.Tests/Tests.fs
@@ -18,6 +18,8 @@ open FSharp.Markdown.Unit
 open NUnit.Framework
 open FSharp.Literate.Tests.Setup
 
+let properNewLines (text: string) = text.Replace("\r\n", System.Environment.NewLine)
+
 // --------------------------------------------------------------------------------------
 // Test embedding code from a file
 // --------------------------------------------------------------------------------------
@@ -118,7 +120,7 @@ hello
 [<Test>]
 let ``Codeblock whitespace is preserved`` () =
   let doc = "```markup\r\n    test\r\n    blub\r\n```\r\n";
-  let expected = "<table class=\"pre\"><tr><td><pre lang=\"markup\">    test\r\n    blub\r\n</pre></td></tr></table>\r\n";
+  let expected = "<table class=\"pre\"><tr><td><pre lang=\"markup\">    test\r\n    blub\r\n</pre></td></tr></table>\r\n" |> properNewLines;
   let doc = Literate.ParseMarkdownString(doc, formatAgent=getFormatAgent())
   let html = Literate.WriteHtml(doc)
   html |> should contain expected

--- a/tests/FSharp.Markdown.Tests/Markdown.fs
+++ b/tests/FSharp.Markdown.Tests/Markdown.fs
@@ -225,6 +225,20 @@ let ``Transform code blocks correctly``() =
     |> shouldEqual expected
 
 [<Test>]
+let ``Transform github flavored code blocks correctly``() =
+    let doc = "code sample:\r\n\r\n```\r\n<head>\r\n<title>page title</title>\r\n</head>\r\n```\r\n";
+    let expected = "<p>code sample:</p>\r\n\r\n<pre><code>&lt;head&gt;\r\n&lt;title&gt;page title&lt;/title&gt;\r\n&lt;/head&gt;\r\n</code></pre>\r\n" |> properNewLines;
+    Markdown.TransformHtml doc
+    |> shouldEqual expected
+    
+[<Test>]
+let ``Transform github flavored language code blocks correctly``() =
+    let doc = "code sample:\r\n\r\n```markup\r\n<head>\r\n<title>page title</title>\r\n</head>\r\n```\r\n";
+    let expected = "<p>code sample:</p>\r\n\r\n<pre class=\"line-numbers language-markup\"><code class=\"language-markup\">&lt;head&gt;\r\n&lt;title&gt;page title&lt;/title&gt;\r\n&lt;/head&gt;\r\n</code></pre>\r\n" |> properNewLines;
+    Markdown.TransformHtml doc
+    |> shouldEqual expected
+
+[<Test>]
 let ``Transform code spans correctly``() =
     let doc = "HTML contains the `<blink>` tag";
     let expected = "<p>HTML contains the <code>&lt;blink&gt;</code> tag</p>\r\n" |> properNewLines;

--- a/tests/FSharp.Markdown.Tests/Markdown.fs
+++ b/tests/FSharp.Markdown.Tests/Markdown.fs
@@ -212,7 +212,7 @@ let ``Transform header 2 correctly``() =
 [<Test>] 
 let ``Transform code blocks in list correctly``() = 
     let doc = "- code sample:\r\n\r\n\r\n    let x = 1\r\n"
-    let expected = "<ul>\r\n<li>code sample:</li>\r\n</ul>\r\n\r\n<pre><code>let x = 1\r\n</code></pre>\r\n" |> properNewLines; 
+    let expected = "<ul>\r\n<li>code sample:</li>\r\n</ul>\r\n\r\n<pre><code>let x = 1</code></pre>\r\n" |> properNewLines; 
     Markdown.TransformHtml doc 
     |> shouldEqual expected 
  
@@ -220,7 +220,7 @@ let ``Transform code blocks in list correctly``() =
 [<Test>]
 let ``Transform code blocks correctly``() =
     let doc = "code sample:\r\n\r\n    <head>\r\n    <title>page title</title>\r\n    </head>\r\n";
-    let expected = "<p>code sample:</p>\r\n\r\n<pre><code>&lt;head&gt;\r\n&lt;title&gt;page title&lt;/title&gt;\r\n&lt;/head&gt;\r\n</code></pre>\r\n" |> properNewLines;
+    let expected = "<p>code sample:</p>\r\n\r\n<pre><code>&lt;head&gt;\r\n&lt;title&gt;page title&lt;/title&gt;\r\n&lt;/head&gt;</code></pre>\r\n" |> properNewLines;
     Markdown.TransformHtml doc
     |> shouldEqual expected
 
@@ -235,6 +235,13 @@ let ``Transform github flavored code blocks correctly``() =
 let ``Transform github flavored language code blocks correctly``() =
     let doc = "code sample:\r\n\r\n```markup\r\n<head>\r\n<title>page title</title>\r\n</head>\r\n```\r\n";
     let expected = "<p>code sample:</p>\r\n\r\n<pre class=\"line-numbers language-markup\"><code class=\"language-markup\">&lt;head&gt;\r\n&lt;title&gt;page title&lt;/title&gt;\r\n&lt;/head&gt;\r\n</code></pre>\r\n" |> properNewLines;
+    Markdown.TransformHtml doc
+    |> shouldEqual expected
+    
+[<Test>]
+let ``Transform github flavored code blocks with whitespace correctly``() =
+    let doc = "```\r\n    test\r\n    blub\r\n```\r\n";
+    let expected = "<pre><code>    test\r\n    blub\r\n</code></pre>\r\n" |> properNewLines;
     Markdown.TransformHtml doc
     |> shouldEqual expected
 


### PR DESCRIPTION
Initial support for github flavored markup code blocks like

    ```lang
    some code
    ```

see also https://github.com/tpetricek/FSharp.Formatting/issues/181.