### PR TITLE
use SourceCodeClassifier from Visual F# Power Tools Core to colorize F# snippets

### DIFF
--- a/docs/files/content/style.css
+++ b/docs/files/content/style.css
@@ -26,7 +26,11 @@ span.f { color:#e1e1e1; }
 span.p { color:#d778dc; }
 /* mutable var or ref cell */
 span.v { color:#d1d1d1; font-weight: bold; }
-
+/* printf formatters */
+span.pf { color:#4ec9b0; }
+/* escaped chars */
+span.e { color:#ff0080; }
+/* mutable var or ref cell */
 /* inactive code */
 span.inactive { color:#808080; }
 /* preprocessor */

--- a/docs/files/content/style.css
+++ b/docs/files/content/style.css
@@ -9,15 +9,23 @@ span.i { color:#d1d1d1; }
 /* string */
 span.s { color:#d4b43c; }
 /* keywords */
-span.k { color:#4e98dc; }
+span.k { color:#569cd6; }
 /* comment */
 span.c { color:#96C71D; }
 /* operators */
-span.o { color:#af75c1; }
+span.o { color:#d1d1d1; }
 /* numbers */
-span.n { color:#96C71D; }
+span.n { color:#b5cea8; }
 /* line number */
 span.l { color:#80b0b0; }
+/* type or module */
+span.t { color:#4ec9b0; }
+/* function */
+span.f { color:#e1e1e1; }
+/* DU case or active pattern */
+span.p { color:#d778dc; }
+/* mutable var or ref cell */
+span.v { color:#d1d1d1; font-weight: bold; }
 
 /* inactive code */
 span.inactive { color:#808080; }

--- a/docs/files/content/style_light.css
+++ b/docs/files/content/style_light.css
@@ -26,6 +26,11 @@ span.f { color:#0000a0; }
 span.p { color:#800080; }
 /* mutable var or ref cell */
 span.v { color:#000000; font-weight: bold; }
+/* printf formatters */
+span.pf { color:#2b91af; }
+/* escaped chars */
+span.e { color:#ff0080; }
+/* mutable var or ref cell */
 
 
 /* inactive code */

--- a/docs/files/content/style_light.css
+++ b/docs/files/content/style_light.css
@@ -1,0 +1,217 @@
+@import url(https://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans+Mono|Open+Sans:400,600,700);
+
+/*-------------------------------------------------------------------------- 
+  Formatting for F# code snippets 
+/*--------------------------------------------------------------------------*/
+
+/* identifier */
+span.i { color:#000000; }
+/* string */
+span.s { color:#a31515; }
+/* keywords */
+span.k { color:#0000ff; }
+/* comment */
+span.c { color:#008000; }
+/* operators */
+span.o { color:#000000; }
+/* numbers */
+span.n { color:#000000; }
+/* line number */
+span.l { color:#96c2cd; }
+/* type or module */
+span.t { color:#2b91af; }
+/* function */
+span.f { color:#0000a0; }
+/* DU case or active pattern */
+span.p { color:#800080; }
+/* mutable var or ref cell */
+span.v { color:#000000; font-weight: bold; }
+
+
+/* inactive code */
+span.inactive { color:#808080; }
+/* preprocessor */
+span.prep { color:#0000ff; }
+/* fsi output */
+span.fsi { color:#808080; }
+
+/* omitted */
+span.omitted { 
+	background:#3c4e52;
+  border-radius:5px;
+	color:#808080;
+	padding:0px 0px 1px 0px;
+}
+/* tool tip */
+div.tip {
+	background:#e5e5e5;
+  border-radius:4px;
+  font:9pt 'Droid Sans', arial, sans-serif;
+	padding:6px 8px 6px 8px;
+	display:none;
+  color:#000000;
+}
+table.pre pre {
+  padding:0px;
+  margin:0px;
+  border:none;
+} 
+table.pre, pre.fssnip, pre {
+  line-height:13pt;
+  border:1px solid #d8d8d8;
+  border-collapse:separate;
+  white-space:pre;
+  font: 10pt consolas,monospace;
+  width:90%;
+  margin:10px 20px 20px 20px;
+  background-color:#fdfdfd;
+  padding:10px;
+  border-radius:5px;
+  color:#000000;  
+}
+table.pre pre {
+  padding:0px;
+  margin:0px;
+  border-radius:0px;
+  width: 100%;
+}
+table.pre td {
+  padding:0px;
+  white-space:normal;
+  margin:0px;
+}
+table.pre td.lines {
+  width:30px;
+}
+
+/*-------------------------------------------------------------------------- 
+  Formatting for page & standard document content
+/*--------------------------------------------------------------------------*/
+
+body {
+  font-family: 'Open Sans', serif;
+  padding-top: 0px;
+  padding-bottom: 40px;
+}
+
+pre {
+    word-wrap: inherit;
+}
+
+/* Format the heading - nicer spacing etc. */
+.masthead {
+  overflow: hidden;
+}
+.masthead .muted a {
+  text-decoration:none;
+  color:#999999;
+}
+.masthead ul, .masthead li {
+  margin-bottom:0px;
+}
+.masthead .nav li {
+  margin-top: 15px;
+  font-size:110%;
+}
+.masthead h3 {
+  margin-bottom:5px;
+  font-size:170%;
+}
+hr {
+  margin:0px 0px 20px 0px;
+}
+
+/* Make table headings and td.title bold */
+td.title, thead {
+  font-weight:bold;
+}
+
+/* Format the right-side menu */
+#menu {
+  margin-top:50px;
+  font-size:11pt;
+  padding-left:20px;
+}
+
+#menu .nav-header {
+  font-size:12pt;
+  color:#606060;
+  margin-top:20px;
+}
+
+#menu li {
+  line-height:25px;
+}
+
+/* Change font sizes for headings etc. */
+#main h1 { font-size: 26pt; margin:10px 0px 15px 0px; font-weight:400; }
+#main h2 { font-size: 20pt; margin:20px 0px 0px 0px; font-weight:400; }
+#main h3 { font-size: 14pt; margin:15px 0px 0px 0px; font-weight:600; }
+#main p  { font-size: 11pt; margin:5px 0px 15px 0px; }
+#main ul { font-size: 11pt; margin-top:10px; }
+#main li { font-size: 11pt; margin: 5px 0px 5px 0px; }
+#main strong { font-weight:700; }
+
+/*-------------------------------------------------------------------------- 
+  Formatting for API reference
+/*--------------------------------------------------------------------------*/
+
+.type-list .type-name, .module-list .module-name {
+  width:25%;
+  font-weight:bold;
+}
+.member-list .member-name {
+  width:35%;
+}
+#main .xmldoc h2 {
+  font-size:14pt;
+  margin:10px 0px 0px 0px;
+}
+#main .xmldoc h3 {
+  font-size:12pt;
+  margin:10px 0px 0px 0px;
+}
+.github-link {
+  float:right;
+  text-decoration:none;
+}
+.github-link img {
+  border-style:none;
+  margin-left:10px;
+}
+.github-link .hover { display:none; }
+.github-link:hover .hover { display:block; }
+.github-link .normal { display: block; }
+.github-link:hover .normal { display: none; }
+
+/*-------------------------------------------------------------------------- 
+  Links 
+/*--------------------------------------------------------------------------*/
+
+h1 a, h1 a:hover, h1 a:focus,
+h2 a, h2 a:hover, h2 a:focus,
+h3 a, h3 a:hover, h3 a:focus,
+h4 a, h4 a:hover, h4 a:focus,
+h5 a, h5 a:hover, h5 a:focus,
+h6 a, h6 a:hover, h6 a:focus { color : inherit; text-decoration : inherit; outline:none }
+
+/*-------------------------------------------------------------------------- 
+  Additional formatting for the homepage 
+/*--------------------------------------------------------------------------*/
+
+#nuget { 
+  margin-top:20px;
+  font-size: 11pt; 
+  padding:20px; 
+}
+
+#nuget pre {
+  font-size:11pt;
+  -moz-border-radius: 0px;
+  -webkit-border-radius: 0px;
+  border-radius: 0px;
+  background: #404040;
+  border-style:none;
+  color: #e0e0e0;
+  margin-top:15px;
+}

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -8,3 +8,4 @@ nuget RazorEngine 3.5.0
 nuget NUnit
 nuget NUnit.Runners
 nuget NuGet.CommandLine
+nuget FSharpVSPowerTools.Core

--- a/paket.lock
+++ b/paket.lock
@@ -4,6 +4,8 @@ NUGET
     CommandLineParser (1.9.71)
     FAKE (3.14.0)
     FSharp.Compiler.Service (0.0.81)
+    FSharpVSPowerTools.Core (1.7.0)
+      FSharp.Compiler.Service (>= 0.0.81)
     Microsoft.AspNet.Razor (2.0.30506.0)
     NuGet.CommandLine (2.8.3)
     NUnit (2.6.4)

--- a/src/FSharp.CodeFormat/FSharp.CodeFormat.fsproj
+++ b/src/FSharp.CodeFormat/FSharp.CodeFormat.fsproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>FSharp.CodeFormat</RootNamespace>
     <AssemblyName>FSharp.CodeFormat</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <Name>FSharp.CodeFormat</Name>
@@ -94,6 +94,9 @@
       <HintPath>..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.3.0.0\FSharp.Core.dll</HintPath>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
+    <Reference Include="FSharpVSPowerTools.Core">
+      <HintPath>..\..\packages\FSharpVSPowerTools.Core\lib\net45\FSharpVSPowerTools.Core.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
@@ -121,6 +124,17 @@
       <ItemGroup>
         <Reference Include="FSharp.Compiler.Service">
           <HintPath>..\..\packages\FSharp.Compiler.Service\lib\net45\FSharp.Compiler.Service.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+      <ItemGroup>
+        <Reference Include="FSharpVSPowerTools.Core">
+          <HintPath>..\..\packages\FSharpVSPowerTools.Core\lib\net45\FSharpVSPowerTools.Core.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/src/FSharp.CodeFormat/HtmlFormatting.fs
+++ b/src/FSharp.CodeFormat/HtmlFormatting.fs
@@ -131,6 +131,10 @@ let rec formatTokenSpans (ctx:FormattingContext) = List.iter (function
         | TokenKind.Operator -> "o"
         | TokenKind.Preprocessor -> "prep"
         | TokenKind.String -> "s"
+        | TokenKind.TypeOrModule -> "t"
+        | TokenKind.Function -> "f"
+        | TokenKind.Pattern -> "p"
+        | TokenKind.MutableVar -> "v"
 
       if kind <> TokenKind.Default then
         // Colorize token & add tool tip

--- a/src/FSharp.CodeFormat/HtmlFormatting.fs
+++ b/src/FSharp.CodeFormat/HtmlFormatting.fs
@@ -135,6 +135,8 @@ let rec formatTokenSpans (ctx:FormattingContext) = List.iter (function
         | TokenKind.Function -> "f"
         | TokenKind.Pattern -> "p"
         | TokenKind.MutableVar -> "v"
+        | TokenKind.Printf -> "pf"
+        | TokenKind.Escaped -> "e"
 
       if kind <> TokenKind.Default then
         // Colorize token & add tool tip

--- a/src/FSharp.CodeFormat/SourceCode.fs
+++ b/src/FSharp.CodeFormat/SourceCode.fs
@@ -25,6 +25,10 @@ type TokenKind =
   | Number
   | Operator
   | Preprocessor
+  | TypeOrModule
+  | Function
+  | Pattern
+  | MutableVar
   | Default
 
 [<RequireQualifiedAccess>]

--- a/src/FSharp.CodeFormat/SourceCode.fs
+++ b/src/FSharp.CodeFormat/SourceCode.fs
@@ -29,6 +29,8 @@ type TokenKind =
   | Function
   | Pattern
   | MutableVar
+  | Printf
+  | Escaped
   | Default
 
 [<RequireQualifiedAccess>]

--- a/src/FSharp.CodeFormat/paket.references
+++ b/src/FSharp.CodeFormat/paket.references
@@ -1,1 +1,2 @@
 FSharp.Compiler.Service
+FSharpVSPowerTools.Core


### PR DESCRIPTION
The result as following, standard (dark) theme:

![image](https://cloud.githubusercontent.com/assets/873919/5892099/21f57bf4-a4c5-11e4-9a8e-afed4f56188b.png)

New light theme:

![image](https://cloud.githubusercontent.com/assets/873919/5892077/ba05c620-a4c4-11e4-9bd8-b1048b3c91e2.png)

Feel free to change the colors of the dark theme as you wish (I make it as close as possible to the colors of VS dark theme (except the color for strings)). 