### PR TITLE
add some search paths to the loading script.

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -80,11 +80,11 @@ Target "Clean" (fun _ ->
 open System.IO
 
 Target "UpdateFsxVersions" (fun _ ->
+    let packages = [ "FSharp.Compiler.Service"; "FSharpVSPowerTools.Core" ]
     let replacements = 
-      [ "packages/FSharp.Compiler.Service.(.*)/lib",
-        sprintf "packages/FSharp.Compiler.Service.%s/lib" (GetPackageVersion "packages" "FSharp.Compiler.Service");
-        "packages/FSharpVSPowerTools.Core.(.*)/lib",
-        sprintf "packages/FSharp.Compiler.Service.%s/lib" (GetPackageVersion "packages" "FSharpVSPowerTools.Core") ]
+      packages |> Seq.map (fun packageName ->
+        sprintf "/%s.(.*)/lib" packageName,
+        sprintf "/%s.%s/lib" packageName (GetPackageVersion "packages" packageName))
     let path = "./src/FSharp.Formatting.fsx"
     let text = File.ReadAllText(path)
     let text = (text, replacements) ||> Seq.fold (fun text (pattern, replacement) ->

--- a/src/FSharp.Formatting.fsx
+++ b/src/FSharp.Formatting.fsx
@@ -3,16 +3,11 @@
 #I "."
 #I "lib/net40"
 
-// Standard NuGet locations 
-#I "../../packages/FSharp.Compiler.Service.0.0.82/lib/net45"
+// Standard NuGet locations
 #I "../FSharp.Compiler.Service.0.0.82/lib/net45"
-
-#I "../../packages/FSharpVSPowerTools.Core.1.7.0/lib/net45"
 #I "../FSharpVSPowerTools.Core.1.7.0/lib/net45"
 
-// Standard Paket locations 
-#I "../../packages/FSharp.Compiler.Service/lib/net45"
-#I "../../packages/FSharpVSPowerTools.Core/lib/net45"
+// Standard Paket locations
 #I "../FSharp.Compiler.Service/lib/net45"
 #I "../FSharpVSPowerTools.Core/lib/net45"
 

--- a/src/FSharp.Formatting.fsx
+++ b/src/FSharp.Formatting.fsx
@@ -4,12 +4,17 @@
 #I "lib/net40"
 
 // Standard NuGet locations 
-#I "../../packages/FSharp.Compiler.Service.0.0.82/lib/net40"
 #I "../../packages/FSharp.Compiler.Service.0.0.82/lib/net45"
+#I "../FSharp.Compiler.Service.0.0.82/lib/net45"
+
+#I "../../packages/FSharpVSPowerTools.Core.1.7.0/lib/net45"
+#I "../FSharpVSPowerTools.Core.1.7.0/lib/net45"
 
 // Standard Paket locations 
-#I "../../packages/FSharp.Compiler.Service/lib/net40"
+#I "../../packages/FSharp.Compiler.Service/lib/net45"
 #I "../../packages/FSharpVSPowerTools.Core/lib/net45"
+#I "../FSharp.Compiler.Service/lib/net45"
+#I "../FSharpVSPowerTools.Core/lib/net45"
 
 // Try various folders that people might like
 #I "bin"


### PR DESCRIPTION
please tell me what you think, nuget folders don't need to be named "packages", but we can kind of assume we are in the right folder...