### PR TITLE
FSharp.Formatting fails on projects using EntityFramework.dll.

### DIFF
--- a/src/FSharp.CodeFormat/FSharp.CodeFormat.fsproj
+++ b/src/FSharp.CodeFormat/FSharp.CodeFormat.fsproj
@@ -93,6 +93,7 @@
     <Reference Include="FSharp.Core, Version=4.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.3.0.0\FSharp.Core.dll</HintPath>
       <SpecificVersion>True</SpecificVersion>
+      <Private>False</Private>
     </Reference>
     <Reference Include="FSharpVSPowerTools.Core">
       <HintPath>..\..\packages\FSharpVSPowerTools.Core\lib\net45\FSharpVSPowerTools.Core.dll</HintPath>

--- a/src/FSharp.Literate/FSharp.Literate.fsproj
+++ b/src/FSharp.Literate/FSharp.Literate.fsproj
@@ -74,6 +74,7 @@
     <Reference Include="FSharp.Core, Version=4.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\..\lib\FSharp.Core.dll</HintPath>
       <SpecificVersion>True</SpecificVersion>
+      <Private>False</Private>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />

--- a/src/FSharp.Markdown/FSharp.Markdown.fsproj
+++ b/src/FSharp.Markdown/FSharp.Markdown.fsproj
@@ -61,6 +61,7 @@
     <Reference Include="FSharp.Core, Version=4.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.3.0.0\FSharp.Core.dll</HintPath>
       <SpecificVersion>True</SpecificVersion>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/FSharp.MetadataFormat/FSharp.MetadataFormat.fsproj
+++ b/src/FSharp.MetadataFormat/FSharp.MetadataFormat.fsproj
@@ -40,6 +40,7 @@
     <Reference Include="FSharp.Core, Version=4.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.3.0.0\FSharp.Core.dll</HintPath>
       <SpecificVersion>True</SpecificVersion>
+      <Private>False</Private>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />

--- a/src/FSharp.MetadataFormat/Main.fs
+++ b/src/FSharp.MetadataFormat/Main.fs
@@ -1035,10 +1035,14 @@ type MetadataFormat =
         |> Seq.map Path.GetFullPath
         |> Seq.filter (fun file -> dllFiles |> List.exists (fun binary -> binary = file) |> not)
 
+      let blacklist =
+        [ "FSharp.Core.dll"; "mscorlib.dll" ]
+
       let dllReferences =
         libDirs
         |> Seq.collect findReferences
         |> Seq.append dllFiles
+        |> Seq.filter (fun file -> blacklist |> List.exists (fun black -> black = Path.GetFileName file) |> not)
 
       let options = 
         checker.GetProjectOptionsFromCommandLineArgs(projFileName,

--- a/src/FSharp.MetadataFormat/Main.fs
+++ b/src/FSharp.MetadataFormat/Main.fs
@@ -993,6 +993,7 @@ type MetadataFormat =
     let otherFlags = defaultArg otherFlags []
     let publicOnly = defaultArg publicOnly true
     let libDirs = defaultArg libDirs []
+    let dllFiles = dllFiles |> List.map Path.GetFullPath
     let urlRangeHighlight =
       defaultArg urlRangeHighlight (fun url start stop -> String.Format("{0}#L{1}-{2}", url, start, stop))
     let sourceFolderRepo =
@@ -1029,6 +1030,16 @@ type MetadataFormat =
       let fileName1 = Path.ChangeExtension(base1, ".fs")
       let projFileName = Path.ChangeExtension(base1, ".fsproj")
       File.WriteAllText(fileName1, """module M""")
+      let findReferences libDir =
+        Directory.EnumerateFiles(libDir, "*.dll")
+        |> Seq.map Path.GetFullPath
+        |> Seq.filter (fun file -> dllFiles |> List.exists (fun binary -> binary = file) |> not)
+
+      let dllReferences =
+        libDirs
+        |> Seq.collect findReferences
+        |> Seq.append dllFiles
+
       let options = 
         checker.GetProjectOptionsFromCommandLineArgs(projFileName,
           [|yield "--debug:full" 
@@ -1040,10 +1051,9 @@ type MetadataFormat =
             yield "--fullpaths" 
             yield "--flaterrors" 
             yield "--target:library" 
-            for dllFile in dllFiles do
+            for dllFile in dllReferences do
               yield "-r:"+dllFile
-            for libDir in libDirs do
-              yield "-I:"+libDir
+            // Libdirs are handled above, see https://github.com/fsharp/FSharp.Compiler.Service/issues/313
             yield! otherFlags
             yield fileName1 |])
       let results = checker.ParseAndCheckProject(options) |> Async.RunSynchronously

--- a/tests/FSharp.CodeFormat.Tests/FSharp.CodeFormat.Tests.fsproj
+++ b/tests/FSharp.CodeFormat.Tests/FSharp.CodeFormat.Tests.fsproj
@@ -94,6 +94,7 @@
     <Reference Include="FSharp.Core, Version=4.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.3.0.0\FSharp.Core.dll</HintPath>
       <SpecificVersion>True</SpecificVersion>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/tests/FSharp.Literate.Tests/FSharp.Literate.Tests.fsproj
+++ b/tests/FSharp.Literate.Tests/FSharp.Literate.Tests.fsproj
@@ -78,6 +78,7 @@
     <Reference Include="FSharp.Core, Version=4.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.3.0.0\FSharp.Core.dll</HintPath>
       <SpecificVersion>True</SpecificVersion>
+      <Private>False</Private>
     </Reference>
     <Reference Include="FSharp.Literate">
       <HintPath>..\..\bin\FSharp.Literate.dll</HintPath>

--- a/tests/FSharp.Markdown.Tests/FSharp.Markdown.Tests.fsproj
+++ b/tests/FSharp.Markdown.Tests/FSharp.Markdown.Tests.fsproj
@@ -84,6 +84,7 @@
     <Reference Include="FSharp.Core, Version=4.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.3.0.0\FSharp.Core.dll</HintPath>
       <SpecificVersion>True</SpecificVersion>
+      <Private>False</Private>
     </Reference>
     <Reference Include="FSharp.Markdown">
       <HintPath>..\..\bin\FSharp.Markdown.dll</HintPath>

--- a/tests/FSharp.MetadataFormat.Tests/FSharp.MetadataFormat.Tests.fsproj
+++ b/tests/FSharp.MetadataFormat.Tests/FSharp.MetadataFormat.Tests.fsproj
@@ -42,7 +42,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="FSharp.MetadataFormat">
       <HintPath>..\..\bin\FSharp.MetadataFormat.dll</HintPath>

--- a/tests/FSharp.MetadataFormat.Tests/files/crefLib/crefLib1.fsproj
+++ b/tests/FSharp.MetadataFormat.Tests/files/crefLib/crefLib1.fsproj
@@ -34,7 +34,7 @@
   <ItemGroup>
     <Reference Include="mscorlib" />
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/tests/FSharp.MetadataFormat.Tests/files/crefLib/crefLib2.fsproj
+++ b/tests/FSharp.MetadataFormat.Tests/files/crefLib/crefLib2.fsproj
@@ -35,7 +35,7 @@
   <ItemGroup>
     <Reference Include="mscorlib" />
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
Add support for projects using nuget packages which exist in the system runtime directory (which is preferred over `-I:`).

See https://github.com/fsharp/FSharp.Compiler.Service/issues/313 for details.

This is an example failure: https://travis-ci.org/matthid/Yaaf.Database/builds/53130951
I currently use the `otherflags` parameter as a workaround, however I think it makes sense to integrate the change into FSharp.Formatting directly...

If I did not overlook any side-effects this should do pretty much the same thing as before (without failing on `EntityFramework.dll`)