### PR TITLE
Use template path if it is rooted.

### DIFF
--- a/src/FSharp.Literate/Formatting.fs
+++ b/src/FSharp.Literate/Formatting.fs
@@ -73,7 +73,7 @@ module internal Templating =
   let private generateFile references contentTag parameters templateOpt output layoutRoots =
     match templateOpt with
     | Some (file:string) when file.EndsWith("cshtml", true, CultureInfo.InvariantCulture) -> 
-        let razor = RazorRender(layoutRoots |> Seq.toList, [], Path.GetFileNameWithoutExtension file, ?references = references)
+        let razor = RazorRender(layoutRoots |> Seq.toList, [], file, ?references = references)
         let props = [ "Properties", dict parameters ]
         let generated = razor.ProcessFile(props)
         File.WriteAllText(output, generated)      


### PR DESCRIPTION
This is a bugfix for the case of an empty layout-root and a full-path template.
This also enables the use of a full-path template outside of the layout-root folders.

This does break ProjectScaffold however as they use a full-path template but depend on the bug that this full path is overwritten by the layout-root folder.
Fix is https://github.com/fsprojects/ProjectScaffold/pull/155