### PR TITLE
Add an API to process a customized LiterateDocument.

### DIFF
--- a/src/FSharp.Literate/Main.fs
+++ b/src/FSharp.Literate/Main.fs
@@ -133,6 +133,13 @@ type Literate private () =
   // Processing functions that handle templating etc.
   // ------------------------------------------------------------------------------------
 
+  /// Process the given literate document
+  static member ProcessDocument
+    ( doc, output, ?templateFile, ?format, ?prefix, ?lineNumbers, ?includeSource, ?generateAnchors,
+      ?replacements, ?layoutRoots, ?assemblyReferences) =
+    let ctx = formattingContext templateFile format prefix lineNumbers includeSource generateAnchors replacements layoutRoots
+    Templating.processFile assemblyReferences doc output ctx
+
   /// Process Markdown document
   static member ProcessMarkdown
     ( input, ?templateFile, ?output, ?format, ?formatAgent, ?prefix, ?compilerOptions, 


### PR DESCRIPTION
as discussed in #282 

You can merge both, select one or select none and remote the `internal` from `Templating`. Either solution is fine with me.

One thing that concerns me is that this style of API doesn't work well with F# composition. For example `ProcessMarkdown` and `ProcessScriptFile` should be able to easily reuse this IMHO.
Maybe we should sometimes in the future refactor all the optional parameters into a record?

One concrete problem how I use it here: https://github.com/matthid/ircdotnet/blob/ci_docs_and_build/generateDocs.fsx#L64
Notice how I need a `ctx` object to customize the transformation depending on the output format (which is what you always want to do with this API). But if you depend only on the `doc` and `output` parameters (`format` is optional) you basically need to depend on F# Formatting internals (eg. using the extension to detect the format). So maybe I should make `format` non-optional (in contrast to their counter-parts).
What do you think (as you seem to like the API more than I do)?