### PR TITLE
fix #229 and #287

### DIFF
--- a/src/FSharp.MetadataFormat/Main.fs
+++ b/src/FSharp.MetadataFormat/Main.fs
@@ -946,8 +946,11 @@ module Reader =
         // an easy way to detect where "value" is coming from, because the entries
         // are completely identical. 
         // We just take the last here because it is the easiest to implement.
+        // Additionally we log a warning just in case this is an issue in the future.
         // See https://github.com/tpetricek/FSharp.Formatting/issues/229
         // and https://github.com/tpetricek/FSharp.Formatting/issues/287
+        if xmlMemberMap.ContainsKey key then 
+          Log.logf "Warning: Duplicate documentation for '%s', one will be ignored!" key
         xmlMemberMap.[key] <- value
 
     let ctx = ReadingContext.Create(publicOnly, assemblyName, xmlMemberMap, sourceFolderRepo, urlRangeHighlight, markDownComments, urlMap)

--- a/src/FSharp.MetadataFormat/Main.fs
+++ b/src/FSharp.MetadataFormat/Main.fs
@@ -942,7 +942,13 @@ module Reader =
           let attr = e.Attribute(XName.Get "name") 
           if attr <> null && not (String.IsNullOrEmpty(attr.Value)) then 
             yield attr.Value, e ] do
-        xmlMemberMap.Add(key, value)
+        // NOTE: We completely ignore duplicate keys and I don't see
+        // an easy way to detect where "value" is coming from, because the entries
+        // are completely identical. 
+        // We just take the last here because it is the easiest to implement.
+        // See https://github.com/tpetricek/FSharp.Formatting/issues/229
+        // and https://github.com/tpetricek/FSharp.Formatting/issues/287
+        xmlMemberMap.[key] <- value
 
     let ctx = ReadingContext.Create(publicOnly, assemblyName, xmlMemberMap, sourceFolderRepo, urlRangeHighlight, markDownComments, urlMap)
 

--- a/tests/FSharp.MetadataFormat.Tests/files/FsLib/Library2.fs
+++ b/tests/FSharp.MetadataFormat.Tests/files/FsLib/Library2.fs
@@ -16,3 +16,19 @@ module Nested =
   type NestedType() = 
     /// Very nested member
     member x.Member = ""
+
+type ITest_Issue229 = abstract member Name : string
+
+type Test_Issue229 (name) =
+    /// instance comment
+    member x.Name = name
+
+    interface ITest_Issue229 with
+        /// interface comment
+        member x.Name = name  
+
+type Test_Issue287 () =
+  /// Function Foo!
+  abstract member Foo: int-> unit
+  /// Empty function for signature
+  default x.Foo a = ()


### PR DESCRIPTION
As the comment explains we can pretty much only take the last:
The entries in the xml file are:

```xml
<member name="P:FsLib.Test_Issue229.Name">
<summary>
 interface comment
</summary>
</member>
<member name="P:FsLib.Test_Issue229.Name">
<summary>
 instance comment
</summary>
</member>
```

and

```xml
<member name="M:FsLib.Test_Issue287.Foo(System.Int32)">
<summary>
 Empty function for signature
</summary>
</member>
<member name="M:FsLib.Test_Issue287.Foo(System.Int32)">
<summary>
 Function Foo!
</summary>
</member>
```

So the underlying problem is that what the F# compiler gives us is just not enough information to be useful for us. Maybe someone can look more deeply into this and *maybe* we can (ab)use the ordering somehow. However this change should be enough to fix #229 and #287 .