### PR TITLE
add back RazorEngine.dll

### DIFF
--- a/packages/FSharp.Formatting/FSharp.Formatting.fsx
+++ b/packages/FSharp.Formatting/FSharp.Formatting.fsx
@@ -11,10 +11,12 @@ if (typeof<System.Web.Razor.ParserResults>.Assembly.GetName().Version.Major <= 2
 // Standard NuGet locations
 #I "../FSharp.Compiler.Service.0.0.87/lib/net45"
 #I "../FSharpVSPowerTools.Core.1.8.0/lib/net45"
+#I "../RazorEngine.3.6.4/lib/net45"
 
 // Standard Paket locations
 #I "../FSharp.Compiler.Service/lib/net45"
 #I "../FSharpVSPowerTools.Core/lib/net45"
+#I "../RazorEngine/lib/net45"
 
 
 // Try various folders that people might like
@@ -24,6 +26,7 @@ if (typeof<System.Web.Razor.ParserResults>.Assembly.GetName().Version.Major <= 2
 #I "lib"
 
 // Reference VS PowerTools, Razor and F# Formatting components
+#r "RazorEngine.dll"
 #r "FSharpVSPowerTools.Core.dll"
 #r "FSharp.Markdown.dll"
 #r "FSharp.Literate.dll"

--- a/packages/FSharp.Formatting/FSharp.Formatting.fsx
+++ b/packages/FSharp.Formatting/FSharp.Formatting.fsx
@@ -11,12 +11,10 @@ if (typeof<System.Web.Razor.ParserResults>.Assembly.GetName().Version.Major <= 2
 // Standard NuGet locations
 #I "../FSharp.Compiler.Service.0.0.87/lib/net45"
 #I "../FSharpVSPowerTools.Core.1.8.0/lib/net45"
-#I "../RazorEngine.3.6.4/lib/net45"
 
 // Standard Paket locations
 #I "../FSharp.Compiler.Service/lib/net45"
 #I "../FSharpVSPowerTools.Core/lib/net45"
-#I "../RazorEngine/lib/net45"
 
 
 // Try various folders that people might like


### PR DESCRIPTION
I must have lost my mind when removing this. Good news is that this only seems to lead to problems with the fsf 2.9 release when using the RazorEngine classes directly in the build scripts. The bad news is ProjectScaffold like projects do this because of the mono workaround :(

And I don't know the root cause of https://github.com/tpetricek/FSharp.Formatting/issues/261 but similar things could happen?

I don't really know how we could reliable prevent something like this in the future. Maybe it is viable to add a step to the build script which clones ProjectScaffold, replaces FSharp.Formatting in the packages folder and tries to generate the docs? This could however lead to problems with dependencies and unnecessary build failures. Maybe paket could help us there by providing a way to install a nuget package file directly (/cc @forki)? This would help in other situations as well if you quickly want to test a nuget package before actually releasing it.