### PR TITLE
Simplify FCS interaction code by using Yaaf.FSharp.Scripting.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.suo
 bin/
 obj/
+paket-files/
 nuget/*.nupkg
 docs/output/
 literate/outputs/*

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ docs/output/
 literate/outputs/*
 packages/*
 !packages/FSharp.Formatting
+packages/FSharp.Formatting/lib
 *.VisualState.xml
 TestResults.xml
 TestResult.xml

--- a/FSharp.Formatting.sln
+++ b/FSharp.Formatting.sln
@@ -7,7 +7,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "project", "project", "{194B
 	ProjectSection(SolutionItems) = preProject
 		build.fsx = build.fsx
 		nuget\FSharp.Formatting.CommandTool.nuspec = nuget\FSharp.Formatting.CommandTool.nuspec
-		src\FSharp.Formatting.fsx = src\FSharp.Formatting.fsx
+		packages\FSharp.Formatting\FSharp.Formatting.fsx = packages\FSharp.Formatting\FSharp.Formatting.fsx
 		nuget\FSharp.Formatting.nuspec = nuget\FSharp.Formatting.nuspec
 		paket.dependencies = paket.dependencies
 		RELEASE_NOTES.md = RELEASE_NOTES.md
@@ -39,9 +39,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{312E452A-1
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "sidebyside", "sidebyside", "{561B2DD7-455E-4464-B585-C8768C633EFC}"
 	ProjectSection(SolutionItems) = preProject
-		docs\content\sidebyside\extensions.md = docs\content\sidebyside\extensions.md
-		docs\content\sidebyside\markdown.md = docs\content\sidebyside\markdown.md
-		docs\content\sidebyside\script.fsx = docs\content\sidebyside\script.fsx
+		docs\content\sidebyside\sideextensions.md = docs\content\sidebyside\sideextensions.md
+		docs\content\sidebyside\sidemarkdown.md = docs\content\sidebyside\sidemarkdown.md
+		docs\content\sidebyside\sidescript.fsx = docs\content\sidebyside\sidescript.fsx
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{BEE70727-0C9E-42DE-A65B-5CB8F4EF1820}"

--- a/nuget/FSharp.Formatting.nuspec
+++ b/nuget/FSharp.Formatting.nuspec
@@ -18,6 +18,8 @@
   </metadata>
   <files>
     <!-- Automatically referenced by VS -->
+    <!-- When including additional .dll files here make sure you update "generate.fsx" as well 
+         (it will trigger a CI build failure when forgotten so not a problem) -->
     <file src="..\bin\CSharpFormat.*" target="lib/net40" />
     <file src="..\bin\FSharp.CodeFormat.*" target="lib/net40" />
     <file src="..\bin\FSharp.Literate.*" target="lib/net40" />

--- a/packages/FSharp.Formatting/FSharp.Formatting.fsx
+++ b/packages/FSharp.Formatting/FSharp.Formatting.fsx
@@ -17,12 +17,6 @@ if (typeof<System.Web.Razor.ParserResults>.Assembly.GetName().Version.Major <= 2
 #I "../FSharpVSPowerTools.Core/lib/net45"
 
 
-// Try various folders that people might like
-#I "bin"
-#I "../bin"
-#I "../../bin"
-#I "lib"
-
 // Reference VS PowerTools, Razor and F# Formatting components
 #r "RazorEngine.dll"
 #r "FSharpVSPowerTools.Core.dll"

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -10,3 +10,5 @@ nuget NuGet.CommandLine
 nuget FSharp.Compiler.Service == 0.0.87
 nuget FSharpVSPowerTools.Core == 1.8.0
 nuget ILRepack 1.22.2
+
+github matthid/Yaaf.FSharp.Scripting src/source/Yaaf.FSharp.Scripting/YaafFSharpScripting.fs

--- a/paket.lock
+++ b/paket.lock
@@ -17,4 +17,4 @@ NUGET
 GITHUB
   remote: matthid/Yaaf.FSharp.Scripting
   specs:
-    src/source/Yaaf.FSharp.Scripting/YaafFSharpScripting.fs (49e6418b0f2210d499ad1afc3b4c52b451c7ba80)
+    src/source/Yaaf.FSharp.Scripting/YaafFSharpScripting.fs (eee80e99f3f6c40eab245f085b983d40590d04d9)

--- a/paket.lock
+++ b/paket.lock
@@ -17,4 +17,4 @@ NUGET
 GITHUB
   remote: matthid/Yaaf.FSharp.Scripting
   specs:
-    src/source/Yaaf.FSharp.Scripting/YaafFSharpScripting.fs (eee80e99f3f6c40eab245f085b983d40590d04d9)
+    src/source/Yaaf.FSharp.Scripting/YaafFSharpScripting.fs (253b322f7da2922c01685a02db45b3f3923d627e)

--- a/paket.lock
+++ b/paket.lock
@@ -17,4 +17,4 @@ NUGET
 GITHUB
   remote: matthid/Yaaf.FSharp.Scripting
   specs:
-    src/source/Yaaf.FSharp.Scripting/YaafFSharpScripting.fs (6c3d0e9c2c3fe150162b6d558a4a6a55e84d6b35)
+    src/source/Yaaf.FSharp.Scripting/YaafFSharpScripting.fs (49e6418b0f2210d499ad1afc3b4c52b451c7ba80)

--- a/paket.lock
+++ b/paket.lock
@@ -17,4 +17,4 @@ NUGET
 GITHUB
   remote: matthid/Yaaf.FSharp.Scripting
   specs:
-    src/source/Yaaf.FSharp.Scripting/YaafFSharpScripting.fs (cc1536cbc9e61704a590fdf352b0df0f28f22150)
+    src/source/Yaaf.FSharp.Scripting/YaafFSharpScripting.fs (6c3d0e9c2c3fe150162b6d558a4a6a55e84d6b35)

--- a/paket.lock
+++ b/paket.lock
@@ -2,15 +2,19 @@ NUGET
   remote: http://nuget.org/api/v2
   specs:
     CommandLineParser (1.9.71)
-    FAKE (3.26.1)
+    FAKE (3.28.8)
     FSharp.Compiler.Service (0.0.87)
     FSharpVSPowerTools.Core (1.8.0)
       FSharp.Compiler.Service (>= 0.0.87)
     ILRepack (1.22.2)
     Microsoft.AspNet.Razor (3.2.3)
-    NuGet.CommandLine (2.8.3)
+    NuGet.CommandLine (2.8.5)
     NUnit (2.6.4)
     NUnit.Runners (2.6.4)
-    RazorEngine (3.6.4)
+    RazorEngine (3.6.6)
       Microsoft.AspNet.Razor (>= 3.0.0) - framework: >= net45
       Microsoft.AspNet.Razor (2.0.30506.0) - framework: >= net40 < net45
+GITHUB
+  remote: matthid/Yaaf.FSharp.Scripting
+  specs:
+    src/source/Yaaf.FSharp.Scripting/YaafFSharpScripting.fs (cc1536cbc9e61704a590fdf352b0df0f28f22150)

--- a/src/Common/Razor.fs
+++ b/src/Common/Razor.fs
@@ -249,7 +249,7 @@ type RazorRender(layoutRoots, namespaces, template:string, ?references : string 
       let templateKey =
         match templatePath with
         | Some p -> new PathTemplateKey(templateName, p, ResolveType.Global, null) :> ITemplateKey
-        | None ->  razorEngine.GetKey(templateName)
+        | None -> razorEngine.GetKey(templateName)
       razorEngine.RunCompile(templateKey, modelType, model, x.WithProperties(properties)))
 
 /// [omit]

--- a/src/FSharp.Literate/Evaluator.fs
+++ b/src/FSharp.Literate/Evaluator.fs
@@ -38,8 +38,7 @@ type FsiEvaluationFailedInfo =
     File : string option
     Exception : exn
     StdErr : string }
-    override x.ToString() = 
-      let errMessage = x.Exception.Message
+    override x.ToString() =
       let indent (s:string) = 
         s.Split([| '\n'; '\r' |], StringSplitOptions.RemoveEmptyEntries)
         |> Array.map(fun x -> "    " + x)

--- a/src/FSharp.Literate/FSharp.Literate.fsproj
+++ b/src/FSharp.Literate/FSharp.Literate.fsproj
@@ -46,6 +46,10 @@
   </PropertyGroup>
   <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
   <ItemGroup>
+    <Compile Include="..\..\paket-files\matthid\Yaaf.FSharp.Scripting\src\source\Yaaf.FSharp.Scripting\YaafFSharpScripting.fs">
+      <Paket>True</Paket>
+      <Link>paket-files/YaafFSharpScripting.fs</Link>
+    </Compile>
     <Compile Include="..\Common\AssemblyInfo.fs">
       <Link>Common\AssemblyInfo.fs</Link>
     </Compile>
@@ -118,6 +122,17 @@
       <ItemGroup>
         <Reference Include="FSharp.Compiler.Service">
           <HintPath>..\..\packages\FSharp.Compiler.Service\lib\net45\FSharp.Compiler.Service.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+      <ItemGroup>
+        <Reference Include="FSharpVSPowerTools.Core">
+          <HintPath>..\..\packages\FSharpVSPowerTools.Core\lib\net45\FSharpVSPowerTools.Core.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/src/FSharp.Literate/FSharp.Literate.fsproj
+++ b/src/FSharp.Literate/FSharp.Literate.fsproj
@@ -131,17 +131,6 @@
   <Choose>
     <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
       <ItemGroup>
-        <Reference Include="FSharpVSPowerTools.Core">
-          <HintPath>..\..\packages\FSharpVSPowerTools.Core\lib\net45\FSharpVSPowerTools.Core.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
-      <ItemGroup>
         <Reference Include="System.Web.Razor">
           <HintPath>..\..\packages\Microsoft.AspNet.Razor\lib\net45\System.Web.Razor.dll</HintPath>
           <Private>True</Private>

--- a/src/FSharp.Literate/paket.references
+++ b/src/FSharp.Literate/paket.references
@@ -1,5 +1,4 @@
 File: YaafFSharpScripting.fs 
 FSharp.Compiler.Service
 Microsoft.AspNet.Razor
-FSharpVSPowerTools.Core
 RazorEngine

--- a/src/FSharp.Literate/paket.references
+++ b/src/FSharp.Literate/paket.references
@@ -1,3 +1,5 @@
+File: YaafFSharpScripting.fs 
 FSharp.Compiler.Service
 Microsoft.AspNet.Razor
+FSharpVSPowerTools.Core
 RazorEngine

--- a/src/FSharp.MetadataFormat/FSharp.MetadataFormat.fsproj
+++ b/src/FSharp.MetadataFormat/FSharp.MetadataFormat.fsproj
@@ -38,6 +38,10 @@
     <DocumentationFile>..\..\bin\FSharp.MetadataFormat.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\..\paket-files\matthid\Yaaf.FSharp.Scripting\src\source\Yaaf.FSharp.Scripting\YaafFSharpScripting.fs">
+      <Paket>True</Paket>
+      <Link>paket-files/YaafFSharpScripting.fs</Link>
+    </Compile>
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>True</Private>
     </Reference>

--- a/src/FSharp.MetadataFormat/paket.references
+++ b/src/FSharp.MetadataFormat/paket.references
@@ -1,3 +1,4 @@
+File: YaafFSharpScripting.fs
 FSharp.Compiler.Service
 Microsoft.AspNet.Razor
 RazorEngine

--- a/tests/FSharp.CodeFormat.Tests/FSharp.CodeFormat.Tests.fsproj
+++ b/tests/FSharp.CodeFormat.Tests/FSharp.CodeFormat.Tests.fsproj
@@ -80,17 +80,17 @@
     <Reference Include="System.Numerics" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\packages\NUnit\lib\nunit.framework.dll</HintPath>
-      <Private>True</Private>
-      <Paket>True</Paket>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\src\FSharp.CodeFormat\FSharp.CodeFormat.fsproj">
       <Name>FSharp.CodeFormat</Name>
       <Project>{341ebf32-d470-4c55-99e9-55f14f7ffbb1}</Project>
       <Private>True</Private>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework">
+      <HintPath>..\..\packages\NUnit\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+      <Paket>True</Paket>
+    </Reference>
   </ItemGroup>
 </Project>

--- a/tests/FSharp.Literate.Tests/FSharp.Literate.Tests.fsproj
+++ b/tests/FSharp.Literate.Tests/FSharp.Literate.Tests.fsproj
@@ -93,6 +93,23 @@
 	</Target>
 	-->
   <Import Project="$(SolutionDir)\.paket\paket.targets" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\FSharp.CodeFormat\FSharp.CodeFormat.fsproj">
+      <Name>FSharp.CodeFormat</Name>
+      <Project>{341ebf32-d470-4c55-99e9-55f14f7ffbb1}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\FSharp.Literate\FSharp.Literate.fsproj">
+      <Name>FSharp.Literate</Name>
+      <Project>{65e6d541-0486-4383-b619-5cfc5d2ba2f0}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\FSharp.Markdown\FSharp.Markdown.fsproj">
+      <Name>FSharp.Markdown</Name>
+      <Project>{c44c1c05-599a-40dd-9590-465eab8960c5}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+  </ItemGroup>
   <Choose>
     <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
       <ItemGroup>
@@ -110,23 +127,6 @@
       <Private>True</Private>
       <Paket>True</Paket>
     </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\FSharp.CodeFormat\FSharp.CodeFormat.fsproj">
-      <Name>FSharp.CodeFormat</Name>
-      <Project>{341ebf32-d470-4c55-99e9-55f14f7ffbb1}</Project>
-      <Private>True</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\..\src\FSharp.Literate\FSharp.Literate.fsproj">
-      <Name>FSharp.Literate</Name>
-      <Project>{65e6d541-0486-4383-b619-5cfc5d2ba2f0}</Project>
-      <Private>True</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\..\src\FSharp.Markdown\FSharp.Markdown.fsproj">
-      <Name>FSharp.Markdown</Name>
-      <Project>{c44c1c05-599a-40dd-9590-465eab8960c5}</Project>
-      <Private>True</Private>
-    </ProjectReference>
   </ItemGroup>
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">

--- a/tests/FSharp.Markdown.Tests/FSharp.Markdown.Tests.fsproj
+++ b/tests/FSharp.Markdown.Tests/FSharp.Markdown.Tests.fsproj
@@ -78,17 +78,17 @@
 	-->
   <Import Project="$(SolutionDir)\.paket\paket.targets" />
   <ItemGroup>
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\packages\NUnit\lib\nunit.framework.dll</HintPath>
-      <Private>True</Private>
-      <Paket>True</Paket>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\src\FSharp.Markdown\FSharp.Markdown.fsproj">
       <Name>FSharp.Markdown</Name>
       <Project>{c44c1c05-599a-40dd-9590-465eab8960c5}</Project>
       <Private>True</Private>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework">
+      <HintPath>..\..\packages\NUnit\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+      <Paket>True</Paket>
+    </Reference>
   </ItemGroup>
 </Project>

--- a/tests/FSharp.MetadataFormat.Tests/FSharp.MetadataFormat.Tests.fsproj
+++ b/tests/FSharp.MetadataFormat.Tests/FSharp.MetadataFormat.Tests.fsproj
@@ -76,6 +76,13 @@
   </Target>
   -->
   <Import Project="$(SolutionDir)\.paket\paket.targets" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\FSharp.MetadataFormat\FSharp.MetadataFormat.fsproj">
+      <Name>FSharp.MetadataFormat</Name>
+      <Project>{bc4946ba-2724-4524-ac50-dfc49ee154a1}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+  </ItemGroup>
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
       <ItemGroup>
@@ -113,13 +120,6 @@
       <Private>True</Private>
       <Paket>True</Paket>
     </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\FSharp.MetadataFormat\FSharp.MetadataFormat.fsproj">
-      <Name>FSharp.MetadataFormat</Name>
-      <Project>{bc4946ba-2724-4524-ac50-dfc49ee154a1}</Project>
-      <Private>True</Private>
-    </ProjectReference>
   </ItemGroup>
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">


### PR DESCRIPTION
*EDIT*

As discussed below, this PR now references the source code of https://github.com/matthid/Yaaf.FSharp.Scripting and fixes several bugs:

 * When specifying an `FsiEvalutator` we currently have the nasty side effect of changing the current directory, this will follow up with a vast number of different exceptions (depending on which paths are relative and which are full)

* The current "fsi"-object workaround did not work on mono.

* When something goes wrong in FCS we get improved exceptions.

* Our own documentation generation has now the same environment, this makes sure we detect problems (like the above) sooner here at FSharp.Formatting (#306).

At the same time the code is simplified.

---------------------------
*Original (continuation of #303)*

We cannot see the "real" error, because FSharp.Formatting is swallowing it...

For the FsLab issue:

The root cause seems to be in https://github.com/tpetricek/FSharp.Formatting/blob/master/src/FSharp.Literate/Evaluator.fs#L130 which pretty much expects all libraries to be available near FSharp.Literate.dll. As it is searching for compile-time assemblies, I'm now wondering why it is actually working on windows. I think we will know more when we have the exact error message...
While I'm looking for the exact error this can already run through the CI build in the mean time...