### PR TITLE
Add API to invalidate templates (RazorEngine 3.7.0).

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -226,6 +226,10 @@ Target "NuGet" (fun _ ->
 Target "GenerateDocs" (fun _ ->
     if not <| executeFSIWithArgs "docs/tools" "generate.fsx" ["--define:RELEASE"; "--define:REFERENCE"; "--define:HELP"] [] then
       failwith "generating reference documentation failed")
+      
+Target "WatchDocs" (fun _ ->
+    if not <| executeFSIWithArgs "docs/tools" "generate.fsx" ["--define:WATCH"] [] then
+      failwith "generating reference documentation failed")
 
 // --------------------------------------------------------------------------------------
 // Release Scripts

--- a/paket.lock
+++ b/paket.lock
@@ -2,7 +2,7 @@ NUGET
   remote: http://nuget.org/api/v2
   specs:
     CommandLineParser (1.9.71)
-    FAKE (3.30.0)
+    FAKE (3.30.3)
     FSharp.Compiler.Service (0.0.87)
     FSharpVSPowerTools.Core (1.8.0)
       FSharp.Compiler.Service (>= 0.0.87)
@@ -11,7 +11,7 @@ NUGET
     NuGet.CommandLine (2.8.5)
     NUnit (2.6.4)
     NUnit.Runners (2.6.4)
-    RazorEngine (3.6.6)
+    RazorEngine (3.7.0)
       Microsoft.AspNet.Razor (>= 3.0.0) - framework: >= net45
       Microsoft.AspNet.Razor (2.0.30506.0) - framework: >= net40 < net45
 GITHUB


### PR DESCRIPTION
Additionally I used this new API to provide `./build.sh WatchDocs` via https://github.com/fsharp/FAKE/pull/766 and RazorEngine 3.7.0

This is really a cool idea taken from FAKE (see linked PR), but improved in performance by not running a new process every time something changes. 

You can now just run `build WatchDocs`, and every documentation edit will trigger a documentation re-creation.

While implementing this I noticed that we have two Razor caches for `FSharp.Literate` and `FSharp.MetadataFormat` which is not ideal. We probably want to have only a single cache (extract the cache to a new F# project?)...