### PR TITLE
Add Module and Namespace in nested module and type pages

### DIFF
--- a/misc/templates/reference/module.cshtml
+++ b/misc/templates/reference/module.cshtml
@@ -35,7 +35,7 @@
 <h1>@Model.Module.Name</h1>
 <p>
   <span>Namespace: @Model.Namespace.Name</span><br />
-  @if(FSharpOption<Module>.get_IsSome(@Model.ParentModule))
+  @if(Model.HasParentModule)
   {
   <span>Parent Module: <a href="@(Model.ParentModule.Value.UrlName).html">@Model.ParentModule.Value.Name</a></span>
   }

--- a/misc/templates/reference/module.cshtml
+++ b/misc/templates/reference/module.cshtml
@@ -34,7 +34,7 @@
 <h1>@Model.Module.Name</h1>
 <p>
   <span>Namespace: @Model.Namespace.Name</span><br />
-  @if(Model.HasParentModule)
+  @if(Model.ParentModule.Exists())
   {
   <span>Parent Module: <a href="@(Model.ParentModule.Value.UrlName).html">@Model.ParentModule.Value.Name</a></span>
   }

--- a/misc/templates/reference/module.cshtml
+++ b/misc/templates/reference/module.cshtml
@@ -33,10 +33,13 @@
 }
 
 <h1>@Model.Module.Name</h1>
-@if(FSharpOption<Module>.get_IsSome(@Model.ParentModule))
-{
-<p>Module: <a href="@(Model.ParentModule.Value.UrlName).html">@Model.ParentModule.Value.Name</a></p>
-}
+<p>
+  <span>Namespace: @Model.Namespace.Name</span><br />
+  @if(FSharpOption<Module>.get_IsSome(@Model.ParentModule))
+  {
+  <span>Parent Module: <a href="@(Model.ParentModule.Value.UrlName).html">@Model.ParentModule.Value.Name</a></span>
+  }
+</p>
 <div class="xmldoc">
   @foreach (var sec in comment.Sections) {
     // XML comment for the type has multiple sections that can be labelled

--- a/misc/templates/reference/module.cshtml
+++ b/misc/templates/reference/module.cshtml
@@ -1,4 +1,5 @@
 @using FSharp.MetadataFormat
+@using Microsoft.FSharp.Core
 @{
   Layout = "template";
   Title = Model.Module.Name + " - " + Properties["project-name"];
@@ -32,6 +33,10 @@
 }
 
 <h1>@Model.Module.Name</h1>
+@if(FSharpOption<Module>.get_IsSome(@Model.ParentModule))
+{
+<p>Module: <a href="@(Model.ParentModule.Value.UrlName).html">@Model.ParentModule.Value.Name</a></p>
+}
 <div class="xmldoc">
   @foreach (var sec in comment.Sections) {
     // XML comment for the type has multiple sections that can be labelled

--- a/misc/templates/reference/module.cshtml
+++ b/misc/templates/reference/module.cshtml
@@ -1,5 +1,4 @@
 @using FSharp.MetadataFormat
-@using Microsoft.FSharp.Core
 @{
   Layout = "template";
   Title = Model.Module.Name + " - " + Properties["project-name"];

--- a/misc/templates/reference/type.cshtml
+++ b/misc/templates/reference/type.cshtml
@@ -1,4 +1,5 @@
 @using FSharp.MetadataFormat
+@using Microsoft.FSharp.Core
 @{
   Layout = "template";
   Title = Model.Type.Name + " - " + Properties["project-name"];
@@ -28,6 +29,10 @@
 }
 
 <h1>@Model.Type.Name</h1>
+@if(FSharpOption<Module>.get_IsSome(@Model.Module))
+{
+<p>Module: <a href="@(Model.Module.Value.UrlName).html">@Model.Module.Value.Name</a></p>
+}
 <div class="xmldoc">
   @foreach (var sec in comment.Sections) {
     // XML comment for the type has multiple sections that can be labelled

--- a/misc/templates/reference/type.cshtml
+++ b/misc/templates/reference/type.cshtml
@@ -31,7 +31,7 @@
 <h1>@Model.Type.Name</h1>
 <p>
   <span>Namespace: @Model.Namespace.Name</span><br />
-  @if(FSharpOption<Module>.get_IsSome(@Model.ParentModule))
+  @if(Model.HasParentModule)
   {
   <span>Parent Module: <a href="@(Model.ParentModule.Value.UrlName).html">@Model.ParentModule.Value.Name</a></span>
   }

--- a/misc/templates/reference/type.cshtml
+++ b/misc/templates/reference/type.cshtml
@@ -29,10 +29,13 @@
 }
 
 <h1>@Model.Type.Name</h1>
-@if(FSharpOption<Module>.get_IsSome(@Model.Module))
-{
-<p>Module: <a href="@(Model.Module.Value.UrlName).html">@Model.Module.Value.Name</a></p>
-}
+<p>
+  <span>Namespace: @Model.Namespace.Name</span><br />
+  @if(FSharpOption<Module>.get_IsSome(@Model.ParentModule))
+  {
+  <span>Parent Module: <a href="@(Model.ParentModule.Value.UrlName).html">@Model.ParentModule.Value.Name</a></span>
+  }
+</p>
 <div class="xmldoc">
   @foreach (var sec in comment.Sections) {
     // XML comment for the type has multiple sections that can be labelled

--- a/misc/templates/reference/type.cshtml
+++ b/misc/templates/reference/type.cshtml
@@ -1,5 +1,4 @@
 @using FSharp.MetadataFormat
-@using Microsoft.FSharp.Core
 @{
   Layout = "template";
   Title = Model.Type.Name + " - " + Properties["project-name"];

--- a/src/FSharp.MetadataFormat/Main.fs
+++ b/src/FSharp.MetadataFormat/Main.fs
@@ -131,7 +131,7 @@ type ModuleInfo =
   { Module : Module
     Assembly : AssemblyGroup
     Namespace : Namespace
-    ParentModule : Option<Module> }
+    ParentModule : Module option }
   member this.HasParentModule = this.ParentModule.IsSome
   static member Create(modul, asm, ns, parent) = 
     { ModuleInfo.Module = modul; Assembly = asm; Namespace = ns; ParentModule = parent }
@@ -140,10 +140,16 @@ type TypeInfo =
   { Type : Type
     Assembly : AssemblyGroup
     Namespace : Namespace
-    ParentModule : Option<Module> }
+    ParentModule : Module option }
   member this.HasParentModule = this.ParentModule.IsSome
   static member Create(typ, asm, ns, modul) = 
     { TypeInfo.Type = typ; Assembly = asm; Namespace = ns; ParentModule = modul }
+
+/// [omit]
+[<System.Runtime.CompilerServices.Extension>]
+module ExtensionMethods =
+   [<System.Runtime.CompilerServices.Extension>]
+   let Exists(opt : Module option) = opt.IsSome
 
 module ValueReader = 
   open System.Collections.ObjectModel

--- a/src/FSharp.MetadataFormat/Main.fs
+++ b/src/FSharp.MetadataFormat/Main.fs
@@ -130,7 +130,7 @@ type AssemblyGroup =
 type ModuleInfo = 
   { Module : Module
     Assembly : AssemblyGroup
-    Namespace : Option<Namespace>
+    Namespace : Namespace
     ParentModule : Option<Module> }
   static member Create(modul, asm, ns, parent) = 
     { ModuleInfo.Module = modul; Assembly = asm; Namespace = ns; ParentModule = parent }
@@ -138,7 +138,7 @@ type ModuleInfo =
 type TypeInfo = 
   { Type : Type
     Assembly : AssemblyGroup
-    Namespace : Option<Namespace>
+    Namespace : Namespace
     Module : Option<Module> }
   static member Create(typ, asm, ns, modul) = 
     { TypeInfo.Type = typ; Assembly = asm; Namespace = ns; Module = modul }
@@ -1159,7 +1159,7 @@ type MetadataFormat =
       for n in modul.NestedModules do yield! nestedModules ns (Some modul) n }
     let moduleInfos = 
       [ for ns in asm.Namespaces do 
-          for n in ns.Modules do yield! nestedModules (Some ns) None n ]
+          for n in ns.Modules do yield! nestedModules ns None n ]
     
     let razor = RazorRender<ModuleInfo>(layoutRoots, ["FSharp.MetadataFormat"], moduleTemplate, ?references = assemblyReferences)
 

--- a/src/FSharp.MetadataFormat/Main.fs
+++ b/src/FSharp.MetadataFormat/Main.fs
@@ -132,6 +132,7 @@ type ModuleInfo =
     Assembly : AssemblyGroup
     Namespace : Namespace
     ParentModule : Option<Module> }
+  member this.HasParentModule = this.ParentModule.IsSome
   static member Create(modul, asm, ns, parent) = 
     { ModuleInfo.Module = modul; Assembly = asm; Namespace = ns; ParentModule = parent }
 
@@ -140,6 +141,7 @@ type TypeInfo =
     Assembly : AssemblyGroup
     Namespace : Namespace
     ParentModule : Option<Module> }
+  member this.HasParentModule = this.ParentModule.IsSome
   static member Create(typ, asm, ns, modul) = 
     { TypeInfo.Type = typ; Assembly = asm; Namespace = ns; ParentModule = modul }
 

--- a/src/FSharp.MetadataFormat/Main.fs
+++ b/src/FSharp.MetadataFormat/Main.fs
@@ -139,9 +139,9 @@ type TypeInfo =
   { Type : Type
     Assembly : AssemblyGroup
     Namespace : Namespace
-    Module : Option<Module> }
+    ParentModule : Option<Module> }
   static member Create(typ, asm, ns, modul) = 
-    { TypeInfo.Type = typ; Assembly = asm; Namespace = ns; Module = modul }
+    { TypeInfo.Type = typ; Assembly = asm; Namespace = ns; ParentModule = modul }
 
 module ValueReader = 
   open System.Collections.ObjectModel
@@ -1174,12 +1174,12 @@ type MetadataFormat =
         TypeInfo.Create(typ, asm, ns, modul)
 
     let rec nestedTypes ns (modul:Module) = seq {
-      yield! (modul.NestedTypes |> List.map (createType (Some ns) (Some modul) ))
+      yield! (modul.NestedTypes |> List.map (createType ns (Some modul) ))
       for n in modul.NestedModules do yield! nestedTypes ns n }
     let typesInfos = 
       [ for ns in asm.Namespaces do 
           for n in ns.Modules do yield! nestedTypes ns n
-          yield! (ns.Types |> List.map (createType (Some ns) None ))  ]
+          yield! (ns.Types |> List.map (createType ns None ))  ]
 
     // Generate documentation for all types
     let razor = new RazorRender<TypeInfo>(layoutRoots, ["FSharp.MetadataFormat"], typeTemplate, ?references = assemblyReferences)

--- a/tests/FSharp.MetadataFormat.Tests/Tests.fs
+++ b/tests/FSharp.MetadataFormat.Tests/Tests.fs
@@ -393,13 +393,24 @@ let ``MetadataFormat processes C# properties on types and includes xml comments 
 
 [<Test>]
 let ``MetadataFormat generates module link in nested types``() = 
-  let library = root @@ "files/TestLib/bin/Debug" @@ "TestLib2.dll"
+  let library = root @@ "files/FsLib/bin/Debug" @@ "FsLib2.dll"
   let output = getOutputDir()
   MetadataFormat.Generate([library], output, layoutRoots, info, libDirs = [root @@ "../../lib"], markDownComments = true)
   let fileNames = Directory.GetFiles(output)
   let files = dict [ for f in fileNames -> Path.GetFileName(f), File.ReadAllText(f) ]
   
   // Check that the link to the module is correctly generated
-  files.["fslib-class.html"] |> should notContain "Module:"
   files.["fslib-nested-nestedtype.html"] |> should contain "Module:"
   files.["fslib-nested-nestedtype.html"] |> should contain "<a href=\"fslib-nested.html\">Nested</a>"
+
+  // Only for nested types
+  files.["fslib-class.html"] |> should notContain "Module:"
+
+  // Check that the link to the module is correctly generated for types in nested modules
+  files.["fslib-nested-submodule-verynestedtype.html"] |> should contain "Module:"
+  files.["fslib-nested-submodule-verynestedtype.html"] |> should contain "<a href=\"fslib-nested-submodule.html\">Submodule</a>"
+
+  // Check that nested submodules have links to its module
+  files.["fslib-nested-submodule.html"] |> should contain "Module:"
+  files.["fslib-nested-submodule.html"] |> should contain "<a href=\"fslib-nested.html\">Nested</a>"
+  

--- a/tests/FSharp.MetadataFormat.Tests/Tests.fs
+++ b/tests/FSharp.MetadataFormat.Tests/Tests.fs
@@ -399,18 +399,25 @@ let ``MetadataFormat generates module link in nested types``() =
   let fileNames = Directory.GetFiles(output)
   let files = dict [ for f in fileNames -> Path.GetFileName(f), File.ReadAllText(f) ]
   
+  // Check that the modules and type files have namespace information
+  files.["fslib-class.html"] |> should contain "Namespace: FsLib"
+  files.["fslib-nested.html"] |> should contain "Namespace: FsLib"
+  files.["fslib-nested-nestedtype.html"] |> should contain "Namespace: FsLib"
+  files.["fslib-nested-submodule.html"] |> should contain "Namespace: FsLib"
+  files.["fslib-nested-submodule-verynestedtype.html"] |> should contain "Namespace: FsLib"
+
   // Check that the link to the module is correctly generated
-  files.["fslib-nested-nestedtype.html"] |> should contain "Module:"
+  files.["fslib-nested-nestedtype.html"] |> should contain "Parent Module:"
   files.["fslib-nested-nestedtype.html"] |> should contain "<a href=\"fslib-nested.html\">Nested</a>"
 
   // Only for nested types
-  files.["fslib-class.html"] |> should notContain "Module:"
+  files.["fslib-class.html"] |> should notContain "Parent Module:"
 
   // Check that the link to the module is correctly generated for types in nested modules
-  files.["fslib-nested-submodule-verynestedtype.html"] |> should contain "Module:"
+  files.["fslib-nested-submodule-verynestedtype.html"] |> should contain "Parent Module:"
   files.["fslib-nested-submodule-verynestedtype.html"] |> should contain "<a href=\"fslib-nested-submodule.html\">Submodule</a>"
 
   // Check that nested submodules have links to its module
-  files.["fslib-nested-submodule.html"] |> should contain "Module:"
+  files.["fslib-nested-submodule.html"] |> should contain "Parent Module:"
   files.["fslib-nested-submodule.html"] |> should contain "<a href=\"fslib-nested.html\">Nested</a>"
   

--- a/tests/FSharp.MetadataFormat.Tests/Tests.fs
+++ b/tests/FSharp.MetadataFormat.Tests/Tests.fs
@@ -390,3 +390,16 @@ let ``MetadataFormat processes C# properties on types and includes xml comments 
     
     files.["manoli-utils-csharpformat-clikeformat.html"] |> should contain "CommentRegEx"
     files.["manoli-utils-csharpformat-clikeformat.html"] |> should contain "Regular expression string to match single line and multi-line"
+
+[<Test>]
+let ``MetadataFormat generates module link in nested types``() = 
+  let library = root @@ "files/TestLib/bin/Debug" @@ "TestLib2.dll"
+  let output = getOutputDir()
+  MetadataFormat.Generate([library], output, layoutRoots, info, libDirs = [root @@ "../../lib"], markDownComments = true)
+  let fileNames = Directory.GetFiles(output)
+  let files = dict [ for f in fileNames -> Path.GetFileName(f), File.ReadAllText(f) ]
+  
+  // Check that the link to the module is correctly generated
+  files.["fslib-class.html"] |> should notContain "Module:"
+  files.["fslib-nested-nestedtype.html"] |> should contain "Module:"
+  files.["fslib-nested-nestedtype.html"] |> should contain "<a href=\"fslib-nested.html\">Nested</a>"

--- a/tests/FSharp.MetadataFormat.Tests/files/FsLib/Library2.fs
+++ b/tests/FSharp.MetadataFormat.Tests/files/FsLib/Library2.fs
@@ -12,6 +12,11 @@ module Nested =
     /// Very nested field
     let supernested = 42
 
+    /// Very nested type
+    type VeryNestedType() =
+      /// Super nested member
+      member x.Member = ""
+
   /// Somewhat nested type
   type NestedType() = 
     /// Very nested member

--- a/tests/FSharp.MetadataFormat.Tests/files/TestLib/Library2.fs
+++ b/tests/FSharp.MetadataFormat.Tests/files/TestLib/Library2.fs
@@ -21,6 +21,13 @@ module Nested =
     /// <summary>Very nested field</summary>
     let supernested = 42
 
+    /// <summary>
+    /// Very nested type
+    /// </summary>
+    type VeryNestedType() =
+      /// <summary>Super nested member</summary>
+      member x.Member = ""
+
   /// <summary>
   /// Somewhat nested type
   /// </summary>


### PR DESCRIPTION
Adds module and namespace information to the "TypeInfo" and "ModuleInfo" types. 
This information is used to add namespace name and links to the parent module in type.cshtml and module.cshtml templates.
Adds test case to review that templates can be generated with correct information.
This will fix #53