### PR TITLE
Add test for parser crash on invalid string

### DIFF
--- a/tests/FSharp.Literate.Tests/Tests.fs
+++ b/tests/FSharp.Literate.Tests/Tests.fs
@@ -498,3 +498,9 @@ let mul a b = a * b
   let doc = Literate.ParseScriptString(source, "/somewhere/test.fsx", getFormatAgent())
   doc.Paragraphs |> shouldMatchPar (function Heading(_, [Literal "demo1"]) -> true | _ -> false)
   doc.Paragraphs |> shouldMatchPar (function Heading(_, [Literal "demo2"]) -> true | _ -> false)
+
+[<Test>]
+let ``Formatter does not crash on source that contains invalid string`` () = 
+  let source = "\"\r\"\n0"
+  let doc = Literate.ParseScriptString(source, "/somewhere/test.fsx", getFormatAgent())
+  Literate.WriteHtml(doc).Length |> should (be greaterThan) 0


### PR DESCRIPTION
The `categorizedSpans` function (defined [https://github.com/tpetricek/FSharp.Formatting/blob/master/src/FSharp.CodeFormat/CodeFormatAgent.fs#L298](here)) crashes when the input string contains incorrect string. Our current way of handling invalid F# code is that we still return something, so it  would be nice to keep this behavior even in this case.

(This was triggered by the F# Snippet: http://fssnip.net/snippet/hH/0, which previously parsed - in some way).

/cc @vasily-kirichenko (or perhaps @dungpa) Could you look into this? This seems to be happening in code that calls Visual F# PowerTools...