### PR TITLE
Adds PaketFormat to not color URLs as comments in Paket files

### DIFF
--- a/src/CSharpFormat/CSharpFormat.csproj
+++ b/src/CSharpFormat/CSharpFormat.csproj
@@ -52,6 +52,7 @@
     <Compile Include="HtmlFormat.cs" />
     <Compile Include="JavaScriptFormat.cs" />
     <Compile Include="MshFormat.cs" />
+    <Compile Include="PaketFormat.cs" />
     <Compile Include="PhpFormat.cs" />
     <Compile Include="Properties\LocalAssemblyInfo.cs" />
     <Compile Include="SourceFormat.cs" />

--- a/src/CSharpFormat/CodeFormat.cs
+++ b/src/CSharpFormat/CodeFormat.cs
@@ -1,4 +1,4 @@
-#region Copyright ©2001-2003 Jean-Claude Manoli [jc@manoli.net]
+#region Copyright © 2001-2003 Jean-Claude Manoli [jc@manoli.net]
 /*
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the author(s) be held liable for any damages arising from

--- a/src/CSharpFormat/CodeFormat.cs
+++ b/src/CSharpFormat/CodeFormat.cs
@@ -87,13 +87,13 @@ namespace Manoli.Utils.CSharpFormat
 			get;
 		}
     
-    /// <summary>
+		/// <summary>
 		/// Can be overridden to provide a list of tokes to be recognized as numbers.
 		/// </summary>
-    protected virtual string NumberRegEx
-    {
-      get { return @"[+-]?\d+(?:\.\d+)?"; }
-    }
+		protected virtual string NumberRegEx
+		{
+			get { return @"[+-]?\d+(?:\.\d+)?"; }
+		}
 
 		/// <summary>
 		/// Determines if the language is case sensitive.
@@ -144,9 +144,9 @@ namespace Manoli.Utils.CSharpFormat
 			regAll.Append(regKeyword);
 			regAll.Append(")|(");
 			regAll.Append(regOps);
-      regAll.Append(")|(");
-      regAll.Append(NumberRegEx);
-      regAll.Append(")");
+			regAll.Append(")|(");
+			regAll.Append(NumberRegEx);
+			regAll.Append(")");
 
 			RegexOptions regexOptions = RegexOptions.Singleline;
 			if (!CaseSensitive) regexOptions |= RegexOptions.IgnoreCase;
@@ -209,7 +209,7 @@ namespace Manoli.Utils.CSharpFormat
 			{
 				return "<span class=\"o\">" + match.ToString() + "</span>";
 			}
-      if(match.Groups[NUMBER_GROUP].Success)
+			if(match.Groups[NUMBER_GROUP].Success)
 			{
 				return "<span class=\"n\">" + match.ToString() + "</span>";
 			}

--- a/src/CSharpFormat/CodeFormat.cs
+++ b/src/CSharpFormat/CodeFormat.cs
@@ -1,4 +1,4 @@
-#region Copyright � 2001-2003 Jean-Claude Manoli [jc@manoli.net]
+#region Copyright ©2001-2003 Jean-Claude Manoli [jc@manoli.net]
 /*
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the author(s) be held liable for any damages arising from

--- a/src/CSharpFormat/CodeFormat.cs
+++ b/src/CSharpFormat/CodeFormat.cs
@@ -115,7 +115,7 @@ namespace Manoli.Utils.CSharpFormat
 		private const int PREPROCESSOR_KEYWORD_GROUP = 3;
 		private const int KEYWORD_GROUP = 4;
 		private const int OPERATOR_GROUP = 5;
-    private const int NUMBER_GROUP = 6;
+		private const int NUMBER_GROUP = 6;
 
 		/// <summary>
 		/// A regular expression that should never match anything.

--- a/src/CSharpFormat/CodeFormat.cs
+++ b/src/CSharpFormat/CodeFormat.cs
@@ -1,4 +1,4 @@
-#region Copyright © 2001-2003 Jean-Claude Manoli [jc@manoli.net]
+#region Copyright ï¿½ 2001-2003 Jean-Claude Manoli [jc@manoli.net]
 /*
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the author(s) be held liable for any damages arising from
@@ -86,6 +86,14 @@ namespace Manoli.Utils.CSharpFormat
 		{
 			get;
 		}
+    
+    /// <summary>
+		/// Can be overridden to provide a list of tokes to be recognized as numbers.
+		/// </summary>
+    protected virtual string NumberRegEx
+    {
+      get { return @"[+-]?\d+(?:\.\d+)?"; }
+    }
 
 		/// <summary>
 		/// Determines if the language is case sensitive.
@@ -107,6 +115,7 @@ namespace Manoli.Utils.CSharpFormat
 		private const int PREPROCESSOR_KEYWORD_GROUP = 3;
 		private const int KEYWORD_GROUP = 4;
 		private const int OPERATOR_GROUP = 5;
+    private const int NUMBER_GROUP = 6;
 
 		/// <summary>
 		/// A regular expression that should never match anything.
@@ -135,7 +144,9 @@ namespace Manoli.Utils.CSharpFormat
 			regAll.Append(regKeyword);
 			regAll.Append(")|(");
 			regAll.Append(regOps);
-			regAll.Append(")");
+      regAll.Append(")|(");
+      regAll.Append(NumberRegEx);
+      regAll.Append(")");
 
 			RegexOptions regexOptions = RegexOptions.Singleline;
 			if (!CaseSensitive) regexOptions |= RegexOptions.IgnoreCase;
@@ -197,6 +208,10 @@ namespace Manoli.Utils.CSharpFormat
 			if(match.Groups[OPERATOR_GROUP].Success)
 			{
 				return "<span class=\"o\">" + match.ToString() + "</span>";
+			}
+      if(match.Groups[NUMBER_GROUP].Success)
+			{
+				return "<span class=\"n\">" + match.ToString() + "</span>";
 			}
 			System.Diagnostics.Debug.Assert(false, "None of the above!");
 			return ""; //none of the above

--- a/src/CSharpFormat/PaketFormat.cs
+++ b/src/CSharpFormat/PaketFormat.cs
@@ -25,7 +25,7 @@ namespace Manoli.Utils.CSharpFormat
         /// </summary>
         protected override string Operators
         {
-            get { return "= == > < >= <= ~> /"; }
+            get { return "= == > < >= <= ~>"; }
         }
         
         /// <summary>

--- a/src/CSharpFormat/PaketFormat.cs
+++ b/src/CSharpFormat/PaketFormat.cs
@@ -4,14 +4,14 @@ using System.Text.RegularExpressions;
 
 namespace Manoli.Utils.CSharpFormat
 {
-	/// <summary>
-	/// Generates color-coded Paket source code.
-	/// </summary>
+    /// <summary>
+    /// Generates color-coded Paket source code.
+    /// </summary>
 	public class PaketFormat : FSharpFormat
 	{
-		/// <summary>
-		/// Regular expression string to match single line and multi-line 
-		/// comments (// and (* *)). Single line comments should not have 
+        /// <summary>
+        /// Regular expression string to match single line and multi-line 
+        /// comments (// and (* *)). Single line comments should not have 
         /// a : before them to avoid color as comments URLs. For example
         /// (source https://nuget.org/api/v2)
 		/// </summary>

--- a/src/CSharpFormat/PaketFormat.cs
+++ b/src/CSharpFormat/PaketFormat.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Manoli.Utils.CSharpFormat
+{
+	/// <summary>
+	/// Generates color-coded Paket source code.
+	/// </summary>
+	public class PaketFormat : FSharpFormat
+	{
+		/// <summary>
+		/// Regular expression string to match single line and multi-line 
+		/// comments (// and (* *)). Single line comments should not have 
+        /// a : before them to avoid color as comments URLs. For example
+        /// (source https://nuget.org/api/v2)
+		/// </summary>
+		protected override string CommentRegEx
+		{
+			get { return @"\(\*.*?\*\)|(?<!\:)//.*?(?=\r|\n)"; }
+		}
+	}
+}

--- a/src/CSharpFormat/PaketFormat.cs
+++ b/src/CSharpFormat/PaketFormat.cs
@@ -19,5 +19,21 @@ namespace Manoli.Utils.CSharpFormat
         {
             get { return @"\(\*.*?\*\)|(?<!\:)//.*?(?=\r|\n)"; }
         }
+        
+        /// <summary>
+        /// Packet operators
+        /// </summary>
+        protected override string Operators
+        {
+            get { return "= == > < >= <= ~> /"; }
+        }
+        
+        /// <summary>
+        /// Matches version numbers
+        /// </summary>
+        protected override string NumberRegEx
+        {
+          get { return @"\b\d+(\.\d+)*\b"; }
+        }
     }
 }

--- a/src/CSharpFormat/PaketFormat.cs
+++ b/src/CSharpFormat/PaketFormat.cs
@@ -7,17 +7,17 @@ namespace Manoli.Utils.CSharpFormat
     /// <summary>
     /// Generates color-coded Paket source code.
     /// </summary>
-	public class PaketFormat : FSharpFormat
+    public class PaketFormat : FSharpFormat
 	{
         /// <summary>
         /// Regular expression string to match single line and multi-line 
         /// comments (// and (* *)). Single line comments should not have 
         /// a : before them to avoid color as comments URLs. For example
         /// (source https://nuget.org/api/v2)
-		/// </summary>
-		protected override string CommentRegEx
-		{
-			get { return @"\(\*.*?\*\)|(?<!\:)//.*?(?=\r|\n)"; }
-		}
-	}
+        /// </summary>
+        protected override string CommentRegEx
+        {
+            get { return @"\(\*.*?\*\)|(?<!\:)//.*?(?=\r|\n)"; }
+        }
+    }
 }

--- a/src/CSharpFormat/SyntaxHighlighter.cs
+++ b/src/CSharpFormat/SyntaxHighlighter.cs
@@ -90,6 +90,9 @@ namespace CSharpFormat
                 case "aspx":
                     sf = new HtmlFormat();
                     break;
+                case "paket":
+                    sf = new PaketFormat();
+                    break;
             }
             if (sf == null)
             {


### PR DESCRIPTION
I just saw issue #262 and decided to give it a try.
I have added the `PaketFormat` class to the `CSharpFormat` project and registered the `paket` language tag.

I am only changing the `CommentsRegex` when matching an inline comment to look if prefix `:` is absent.

I was not able to find tests for this project, but I generated documentation for my latest changes to FAKE and the results are the following:

__Before__
![image](https://cloud.githubusercontent.com/assets/403823/10765263/2f073dce-7cd2-11e5-9b8b-60bb8c14f0c6.png)
 
__After__
![image](https://cloud.githubusercontent.com/assets/403823/10765269/35de147e-7cd2-11e5-9ff4-e9e1e7885478.png)
