### PR TITLE
Add ComiledName to members with F# specific naming

### DIFF
--- a/misc/templates/reference/part-members.cshtml
+++ b/misc/templates/reference/part-members.cshtml
@@ -33,9 +33,9 @@
           }
           @it.Comment.FullText
           @if (!String.IsNullOrEmpty(it.Details.FormatCompiledName))
-		  {
-			  @:<p>CompiledName: <code>@it.Details.FormatCompiledName</code></p>
-		  }
+          {
+              @:<p>CompiledName: <code>@it.Details.FormatCompiledName</code></p>
+          }
         </td>
       </tr>
     }

--- a/misc/templates/reference/part-members.cshtml
+++ b/misc/templates/reference/part-members.cshtml
@@ -32,6 +32,10 @@
             </a>
           }
           @it.Comment.FullText
+          @if (!String.IsNullOrEmpty(it.Details.FormatCompiledName))
+		  {
+			  @:<p>CompiledName: <strong>@it.Details.FormatCompiledName</strong></p>
+		  }
         </td>
       </tr>
     }

--- a/misc/templates/reference/part-members.cshtml
+++ b/misc/templates/reference/part-members.cshtml
@@ -34,7 +34,7 @@
           @it.Comment.FullText
           @if (!String.IsNullOrEmpty(it.Details.FormatCompiledName))
 		  {
-			  @:<p>CompiledName: <strong>@it.Details.FormatCompiledName</strong></p>
+			  @:<p>CompiledName: <code>@it.Details.FormatCompiledName</code></p>
 		  }
         </td>
       </tr>


### PR DESCRIPTION
F# allows to specify CompiledName for variables/members/etc..
It would be usefull to display the CompiledName -- it is important when accessing the entry from a .NET language other than F# (msdn quote)...

MSDN does so, e.g.  https://msdn.microsoft.com/en-us/library/ee370346.aspx
> This function is named Map in compiled assemblies. If you are accessing the function from a .NET language other than F#, or through reflection, use this name.

Note:
The compiled names are only added when the CompiledName differs from the DisplayName.