### PR TITLE
Make logging to file optional using environment variable

### DIFF
--- a/FSharp.Formatting.sln
+++ b/FSharp.Formatting.sln
@@ -30,6 +30,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{312E452A-1
 	ProjectSection(SolutionItems) = preProject
 		docs\content\codeformat.fsx = docs\content\codeformat.fsx
 		docs\content\commandline.md = docs\content\commandline.md
+		docs\content\diagnostics.md = docs\content\diagnostics.md
 		docs\content\evaluation.fsx = docs\content\evaluation.fsx
 		docs\content\index.md = docs\content\index.md
 		docs\content\literate.fsx = docs\content\literate.fsx

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,13 @@
+## 2.13.1 (12 January, 2016)
+ - Make logging to file optional using environment variable
+
 ## 2.13.0 (30 December, 2015)
  - Be compatible with the common-mark spec for 'Fenced code blocks' and 'Indented code blocks'.
    See https://github.com/tpetricek/FSharp.Formatting/pull/343.
    Please follow-up by adding support for more sections of the spec!
    Just add the section to https://github.com/tpetricek/FSharp.Formatting/blob/master/tests/FSharp.Markdown.Tests/CommonMarkSpecTest.fs#L20
    and fix the newly enabled tests.
- - Add ComiledName to members with F# specific naming (https://github.com/tpetricek/FSharp.Formatting/pull/372)
+ - Add CompiledName to members with F# specific naming (https://github.com/tpetricek/FSharp.Formatting/pull/372)
 
 ## 2.12.1 (24 December, 2015)
  - update dependencies

--- a/docs/content/diagnostics.md
+++ b/docs/content/diagnostics.md
@@ -1,0 +1,63 @@
+﻿Diagnostics and debugging
+=========================
+
+The F# Formatting library has an extensive logging to help developers diagnose
+potential issues. If you encounter any issues with F# Formatting, this
+page gives you all the information you need to create a log file with detailed
+trace of what is going one. This may give you some hints on what is wrong & a
+detailed report that you can send when [submitting an
+issue](https://github.com/tpetricek/FSharp.Formatting/issues).
+
+Setting up logging
+------------------
+
+Logging is enabled when you reference F# Formatting using the `FSharp.Formatting.fsx`
+load script. If you're not using the load script, you can enable logging manually
+(just see [how this is done in the load script](https://github.com/tpetricek/FSharp.Formatting/blob/master/packages/FSharp.Formatting/FSharp.Formatting.fsx)).
+
+By default, F# Formatting logs some information to the console output. 
+Detailed logging is enabled by setting an environment variable `FSHARP_FORMATTING_LOG` to 
+`ALL`. The log file `FSharp.Formatting.svclog` will be placed in the directory from where 
+you run the tool. If you are using [ProjectScaffold](https://github.com/fsprojects/ProjectScaffold), 
+then this is the folder from where you run the `build.sh` or `build.cmd` script.
+
+You can set `FSHARP_FORMATTING_LOG` as follows:
+
+ - `NONE` - Disable all logging. F# Formatting will not print anything to the console
+   and it will also not produce a log file (this is not recomended, but you might need
+   this if you want to suppress all output).
+ - `ALL` - Enables detailed logging to a file `FSharp.Formatting.svclog` and keeps 
+   printing of basic information to console too.
+ - `FILE_ONLY` - Enables detailed logging to a file `FSharp.Formatting.svclog` but disables
+   printing of basic information to console.
+ - Any other value (default) - Print basic information to console and do not produce
+   a detailed log file.
+
+Enabling logging on Windows
+---------------------------
+
+On Windows, you can set environment variables by going to system properties
+(this varies depending on the OS version, but generally right click on
+"My Computer" and select a link or button saying something like "Change settings").
+
+This should open a new dialog, where you can go to "Advanced", and click on the
+"Environment Variables" button. Here, you can add the variable as either per-user
+or per-system and save it. 
+
+Enabling logging on Mac/Linux
+-----------------------------
+
+If you're using Linux or Mac, then the easiest option is to set the
+variable from Terminal and then start either Xamarin Studio or the build script from terminal. Note that
+if you set the environment variable from terminal, but launch Xamarin Studio
+from Dock or in some other way, it will not see the variable!
+
+The following should do the trick (assuming the folder `/Users/tomasp/Temp` exists):
+
+    [lang=text]
+    export FSHARP_FORMATTING_LOG=ALL
+    open -n /Applications/Xamarin\ Studio.app/
+
+This will set the variable and start a new instance of Xamarin Studio in the current
+context. Once it appears, reporduce the operation that causes the error, close
+Xamarin Studio and look at the log file.

--- a/docs/tools/template-sidebyside.cshtml
+++ b/docs/tools/template-sidebyside.cshtml
@@ -78,6 +78,7 @@
             <li class="nav-header">Documentation</li>
             <li><a href="@Root/reference/index.html">API Reference</a></li>
             <li><a href="@Root/development.html">Contribute / Development Topics</a></li>
+            <li><a href="@Root/diagnostics.html">Diagnostics &amp; debugging</a></li>
             <li class="divider"></li>
             <li><a href="@Root/reference/fsharp-markdown-markdown.html">Markdown type</a></li>
             <li><a href="@Root/reference/fsharp-codeformat-codeformat.html">CodeFormat type</a></li>

--- a/docs/tools/template.cshtml
+++ b/docs/tools/template.cshtml
@@ -66,6 +66,7 @@
             <li class="nav-header">Documentation</li>
             <li><a href="@Root/reference/index.html">API Reference</a></li>
             <li><a href="@Root/development.html">Contribute / Development Topics</a></li>
+            <li><a href="@Root/diagnostics.html">Diagnostics &amp; debugging</a></li>
             <li class="divider"></li>
             <li><a href="@Root/reference/fsharp-markdown-markdown.html">Markdown type</a></li>
             <li><a href="@Root/reference/fsharp-codeformat-codeformat.html">CodeFormat type</a></li>


### PR DESCRIPTION
Following the discussion here: https://github.com/tpetricek/FsSnip.Website/issues/32

I would prefer to keep the logging to a file optional. I added a new documentation page that explains how to enable this so that when people get an error, we can point them to the docs on how to get a detailed log :)