### PR TITLE
Colors paket keywords

### DIFF
--- a/src/CSharpFormat/CodeFormat.cs
+++ b/src/CSharpFormat/CodeFormat.cs
@@ -141,7 +141,7 @@ namespace Manoli.Utils.CSharpFormat
 		protected string ConcatenateRegex(string commentRegex, string stringRegex, string preprocessorRegex,
 		  string keywordRegex, string operatorsRegex, string numberRegex)
 		{
-      // Build a master regex with capturing groups.
+			// Build a master regex with capturing groups.
 			// Note that the group numbers must with the constants COMMENT_GROUP, OPERATOR_GROUP...!
 			StringBuilder regAll = new StringBuilder();
 			regAll.Append("(");
@@ -159,12 +159,12 @@ namespace Manoli.Utils.CSharpFormat
 			regAll.Append(")");
       
 			return regAll.ToString();
-    }
+		}
 
 		protected string BuildRegex(string separated)
 		{
 			if (separated.Length == 0) return "";
-      var sb = new StringBuilder(separated);
+			var sb = new StringBuilder(separated);
       
 			Sanitize(sb);
 			
@@ -181,7 +181,7 @@ namespace Manoli.Utils.CSharpFormat
 			foreach (var c in new char[] { '&', '?', '*', '.', '<', '>', '[', ']', '^', '|', '(', ')', '#', '+' }) {
 				sb.Replace(c.ToString(), "\\" + c);
 			}
-    }
+		}
 
 		/// <summary>
 		/// Called to evaluate the HTML fragment corresponding to each 

--- a/src/CSharpFormat/PaketFormat.cs
+++ b/src/CSharpFormat/PaketFormat.cs
@@ -21,11 +21,20 @@ namespace Manoli.Utils.CSharpFormat
         }
         
         /// <summary>
-        /// Packet operators
+        /// Paket operators
         /// </summary>
         protected override string Operators
         {
-            get { return "= == > < >= <= ~>"; }
+            get { return "== >= <= ~> ! @ ~ : < > ="; }
+        }
+        
+        /// <summary>
+        /// Paket Keywords
+        /// </summary>
+        protected override string Keywords
+        {
+            get { return "source nuget\\s github\\s gist\\s git\\s http\\s group framework version_in_path content " 
+              + "copy_local redirects import_targets references strategy NUGET GITHUB GROUP GIT specs remote File"; }
         }
         
         /// <summary>
@@ -34,6 +43,33 @@ namespace Manoli.Utils.CSharpFormat
         protected override string NumberRegEx
         {
           get { return @"\b\d+(\.\d+)*\b"; }
+        }
+        
+        public PaketFormat()
+        {
+            var regKeyword = BuildKeywordsRegex(Keywords);
+            var regPreproc = BuildRegex(Preprocessors);
+            var regOps = BuildRegex(Operators);
+            
+            if (regOps.Length == 0) regOps = IMPOSSIBLE_MATCH_REGEX;
+            if (regPreproc.Length == 0) regPreproc = IMPOSSIBLE_MATCH_REGEX;
+
+            var regAll = ConcatenateRegex(CommentRegEx, StringRegEx, regPreproc, regKeyword, regOps, NumberRegEx);
+
+            RegexOptions regexOptions = RegexOptions.Singleline;
+            if (!CaseSensitive) regexOptions |= RegexOptions.IgnoreCase;
+            CodeRegex = new Regex(regAll.ToString(), regexOptions);
+        }
+      
+        protected string BuildKeywordsRegex(string separated)
+        {
+            if (separated.Length == 0) return "";
+            var sb = new StringBuilder(separated);
+          
+            Sanitize(sb);
+            
+            sb.Replace(" ", @"\b|\b");
+            return @"\b" + sb.ToString() + @"\b";
         }
     }
 }

--- a/tests/FSharp.Literate.Tests/Tests.fs
+++ b/tests/FSharp.Literate.Tests/Tests.fs
@@ -274,6 +274,79 @@ let ``Correctly encodes already encoded HTML entities and tags`` () =
     html |> should contain "&lt;em&gt;"
   )
 
+[<Test>]
+let ``Urls are not recognized as comments in Paket code blocks`` () =
+  let content = """
+    [lang=packet]
+    source https://nuget.org/api/v2"""
+  let doc = Literate.ParseMarkdownString(content, formatAgent=getFormatAgent())
+  let html = Literate.WriteHtml(doc)
+  html |> should contain @"https://nuget.org/api/v2"
+
+[<Test>]
+let ``Correctly handles Paket coloring`` () =
+  let content = """
+    [lang=paket]
+    references: strict
+    framework: net35, net40
+    content: none
+    import_targets: false
+    copy_local: false
+    redirects: on
+    strategy: min
+    source https://nuget.org/api/v2 // nuget.org
+    
+    // NuGet packages
+    nuget NUnit ~> 2.6.3
+    nuget FAKE ~> 3.4
+    nuget DotNetZip == 1.9
+    nuget SourceLink.Fake
+    nuget xunit.runners.visualstudio >= 2.0 version_in_path: true
+    nuget Example @~> 1.2 // use "max" version resolution strategy
+    nuget Example2 !~> 1.2 // use "min" version resolution strategy
+    nuget Example-A @> 0
+    
+    // Files from GitHub repositories
+    github forki/FsUnit FsUnit.fs
+    
+    // Gist files
+    gist Thorium/1972349 timestamp.fs
+    
+    // HTTP resources
+    http http://www.fssnip.net/1n decrypt.fs"""
+    
+    let doc = Literate.ParseMarkdownString(content, formatAgent=getFormatAgent())
+    let html = Literate.WriteHtml(doc)
+    
+    html |> should contain "<span class=\"k\">nuget </span>"
+    html |> should contain "<span class=\"k\">github </span>"
+    html |> should contain "<span class=\"k\">gist </span>"
+    html |> should contain "<span class=\"k\">http </span>"
+    html |> should contain "<span class=\"k\">references</span>"
+    html |> should contain "<span class=\"k\">framework</span>"
+    html |> should contain "<span class=\"k\">content</span>"
+    html |> should contain "<span class=\"k\">import_targets</span>"
+    html |> should contain "<span class=\"k\">copy_local</span>"
+    html |> should contain "<span class=\"k\">redirects</span>"
+    html |> should contain "<span class=\"k\">strategy</span>"
+    html |> should contain "<span class=\"k\">version_in_path</span>"
+    
+    html |> should contain "<span class=\"o\">~&gt;</span>"
+    html |> should contain "<span class=\"o\">&gt;=</span>"
+    html |> should contain "<span class=\"o\">==</span>"
+    html |> should contain "<span class=\"o\">!</span><span class=\"o\">~&gt;</span>"
+    html |> should contain "<span class=\"o\">@</span><span class=\"o\">~&gt;</span>"
+    html |> should contain "<span class=\"o\">@</span><span class=\"o\">&gt;</span>"
+    
+    
+    html |> should contain "<span class=\"n\">3.4</span>"
+    html |> should contain "<span class=\"n\">2.6.3</span>"
+    
+    html |> should contain "<span class=\"c\">// NuGet packages</span>"
+    html |> should contain "<span class=\"c\">// nuget.org</span>"
+    
+    html |> should contain @"https://nuget.org/api/v2"
+    html |> should contain @"http://www.fssnip.net/1n"
 
 [<Test>]
 let ``Generates line numbers for F# code snippets`` () =

--- a/tests/FSharp.Literate.Tests/Tests.fs
+++ b/tests/FSharp.Literate.Tests/Tests.fs
@@ -315,38 +315,37 @@ let ``Correctly handles Paket coloring`` () =
     // HTTP resources
     http http://www.fssnip.net/1n decrypt.fs"""
     
-    let doc = Literate.ParseMarkdownString(content, formatAgent=getFormatAgent())
-    let html = Literate.WriteHtml(doc)
-    
-    html |> should contain "<span class=\"k\">nuget </span>"
-    html |> should contain "<span class=\"k\">github </span>"
-    html |> should contain "<span class=\"k\">gist </span>"
-    html |> should contain "<span class=\"k\">http </span>"
-    html |> should contain "<span class=\"k\">references</span>"
-    html |> should contain "<span class=\"k\">framework</span>"
-    html |> should contain "<span class=\"k\">content</span>"
-    html |> should contain "<span class=\"k\">import_targets</span>"
-    html |> should contain "<span class=\"k\">copy_local</span>"
-    html |> should contain "<span class=\"k\">redirects</span>"
-    html |> should contain "<span class=\"k\">strategy</span>"
-    html |> should contain "<span class=\"k\">version_in_path</span>"
-    
-    html |> should contain "<span class=\"o\">~&gt;</span>"
-    html |> should contain "<span class=\"o\">&gt;=</span>"
-    html |> should contain "<span class=\"o\">==</span>"
-    html |> should contain "<span class=\"o\">!</span><span class=\"o\">~&gt;</span>"
-    html |> should contain "<span class=\"o\">@</span><span class=\"o\">~&gt;</span>"
-    html |> should contain "<span class=\"o\">@</span><span class=\"o\">&gt;</span>"
-    
-    
-    html |> should contain "<span class=\"n\">3.4</span>"
-    html |> should contain "<span class=\"n\">2.6.3</span>"
-    
-    html |> should contain "<span class=\"c\">// NuGet packages</span>"
-    html |> should contain "<span class=\"c\">// nuget.org</span>"
-    
-    html |> should contain @"https://nuget.org/api/v2"
-    html |> should contain @"http://www.fssnip.net/1n"
+  let doc = Literate.ParseMarkdownString(content, formatAgent=getFormatAgent())
+  let html = Literate.WriteHtml(doc)
+  
+  html |> should contain "<span class=\"k\">nuget </span>"
+  html |> should contain "<span class=\"k\">github </span>"
+  html |> should contain "<span class=\"k\">gist </span>"
+  html |> should contain "<span class=\"k\">http </span>"
+  html |> should contain "<span class=\"k\">references</span>"
+  html |> should contain "<span class=\"k\">framework</span>"
+  html |> should contain "<span class=\"k\">content</span>"
+  html |> should contain "<span class=\"k\">import_targets</span>"
+  html |> should contain "<span class=\"k\">copy_local</span>"
+  html |> should contain "<span class=\"k\">redirects</span>"
+  html |> should contain "<span class=\"k\">strategy</span>"
+  html |> should contain "<span class=\"k\">version_in_path</span>"
+  
+  html |> should contain "<span class=\"o\">~&gt;</span>"
+  html |> should contain "<span class=\"o\">&gt;=</span>"
+  html |> should contain "<span class=\"o\">==</span>"
+  html |> should contain "<span class=\"o\">!</span><span class=\"o\">~&gt;</span>"
+  html |> should contain "<span class=\"o\">@</span><span class=\"o\">~&gt;</span>"
+  html |> should contain "<span class=\"o\">@</span><span class=\"o\">&gt;</span>"
+
+  html |> should contain "<span class=\"n\">3.4</span>"
+  html |> should contain "<span class=\"n\">2.6.3</span>"
+
+  html |> should contain "<span class=\"c\">// NuGet packages</span>"
+  html |> should contain "<span class=\"c\">// nuget.org</span>"
+  
+  html |> should contain @"https://nuget.org/api/v2"
+  html |> should contain @"http://www.fssnip.net/1n"
 
 [<Test>]
 let ``Generates line numbers for F# code snippets`` () =


### PR DESCRIPTION
Related to issue #262
On PR #349 @tpetricek  said that it would be awesome to have colorization for Paket keywords so I implemented.
This PR:
 - Adds coloring to Paket keywords.
 - Adds some missing operators.
 - Adds Test cases for Paket coloring

Some keywords are also part of urls, so a small refactoring was done to be able to change the Regex builder from white-space separated keywords in order to restrict the recognition of this keywords.
Implemented test cases for paket coloring.

After this, Paket code blocks will look like
![image](https://cloud.githubusercontent.com/assets/403823/12419809/a3973a36-beb8-11e5-8d84-cb82b7c6f040.png)
