### PR TITLE
Reliable getTypeLink.

### DIFF
--- a/src/FSharp.MetadataFormat/Main.fs
+++ b/src/FSharp.MetadataFormat/Main.fs
@@ -659,10 +659,15 @@ module Reader =
 
   /// Returns a tuple of the undefined link and its Cref if it exists
   let getTypeLink (ctx:ReadingContext) undefinedLink =
-    // Append 'T:' to try to get the link from urlmap
-    match ctx.UrlMap.ResolveCref ("T:" + undefinedLink) with
-    | Some cRef -> if cRef.IsInternal then Some (undefinedLink, cRef) else None
-    | None -> None
+    try 
+        // Log.infof "Get type link of:%s " undefinedLink 
+        // Append 'T:' to try to get the link from urlmap
+        match ctx.UrlMap.ResolveCref ("T:" + undefinedLink) with
+        | Some cRef -> if cRef.IsInternal then Some (undefinedLink, cRef) else None
+        | None -> None
+    with 
+    | ex -> 
+        None
 
   /// Adds a cross-type link to the document defined links
   let addLinkToType (doc: LiterateDocument) link =


### PR DESCRIPTION
For

let getTypeLink (ctx:ReadingContext) undefinedLink

Before the change, when the link is undefined, the FSharp.Formatting will crash. The change will allow an undefinedLink to return None, and let the rest of the parsing completes.