### PR TITLE
Fixes issues in PaketFormat

### DIFF
--- a/src/CSharpFormat/PaketFormat.cs
+++ b/src/CSharpFormat/PaketFormat.cs
@@ -17,7 +17,7 @@ namespace Manoli.Utils.CSharpFormat
         /// </summary>
         protected override string CommentRegEx
         {
-            get { return @"\(\*.*?\*\)|(?<!\:)//.*?(?=\r|\n)"; }
+            get { return @"\(\*.*?\*\)|(?<!\:|\:/)//.*?(?:\r|\n|$)"; }
         }
         
         /// <summary>
@@ -34,7 +34,7 @@ namespace Manoli.Utils.CSharpFormat
         protected override string Keywords
         {
             get { return "source nuget\\s github\\s gist\\s git\\s http\\s group framework version_in_path content " 
-              + "copy_local redirects import_targets references strategy NUGET GITHUB GROUP GIT specs remote File"; }
+              + "copy_local redirects import_targets references strategy NUGET GITHUB GROUP GIT HTTP specs remote File"; }
         }
         
         /// <summary>

--- a/tests/FSharp.Literate.Tests/Tests.fs
+++ b/tests/FSharp.Literate.Tests/Tests.fs
@@ -313,8 +313,11 @@ let ``Correctly handles Paket coloring`` () =
     gist Thorium/1972349 timestamp.fs
     
     // HTTP resources
-    http http://www.fssnip.net/1n decrypt.fs"""
+    http http://www.fssnip.net/1n decrypt.fs
     
+    // GIT tags
+    git file:///C:\Users\Steffen\AskMe >= 1 alpha      // at least 1.0 including alpha versions
+    """
   let doc = Literate.ParseMarkdownString(content, formatAgent=getFormatAgent())
   let html = Literate.WriteHtml(doc)
   
@@ -346,6 +349,9 @@ let ``Correctly handles Paket coloring`` () =
   
   html |> should contain @"https://nuget.org/api/v2"
   html |> should contain @"http://www.fssnip.net/1n"
+  
+  html |> should contain @"file:///C:\Users\Steffen\AskMe"
+  html |> should contain "<span class=\"c\">// at least 1.0 including alpha versions</span>"
 
 [<Test>]
 let ``Generates line numbers for F# code snippets`` () =


### PR DESCRIPTION
Fixes issues reported in fsprojects/Paket#1419

 - Adds "HTTP" to list of Paket keywords.
 - Adds :/ to list of prefixes to check that are not present when matching a comment
 - Extends test of Paket coloring.