### PR TITLE
Fixes code-block's width in safari

### DIFF
--- a/docs/files/content/style.css
+++ b/docs/files/content/style.css
@@ -1,7 +1,7 @@
 @import url(https://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans+Mono|Open+Sans:400,600,700);
 
-/*-------------------------------------------------------------------------- 
-  Formatting for F# code snippets 
+/*--------------------------------------------------------------------------
+  Formatting for F# code snippets
 /*--------------------------------------------------------------------------*/
 
 /* strings --- and stlyes for other string related formats */
@@ -40,7 +40,7 @@ span.prep { color:#af75c1; }
 span.fsi { color:#808080; }
 
 /* omitted */
-span.omitted { 
+span.omitted {
 	background:#3c4e52;
   border-radius:5px;
 	color:#808080;
@@ -59,7 +59,7 @@ table.pre pre {
   padding:0px;
   margin:0px;
   border:none;
-} 
+}
 table.pre, pre.fssnip, pre {
   line-height:13pt;
   border:1px solid #d8d8d8;
@@ -71,7 +71,8 @@ table.pre, pre.fssnip, pre {
   background-color:#212d30;
   padding:10px;
   border-radius:5px;
-  color:#d1d1d1;  
+  color:#d1d1d1;
+  max-width: none;
 }
 pre.fssnip code {
   font: 9pt 'Droid Sans Mono',consolas,monospace;
@@ -91,7 +92,7 @@ table.pre td.lines {
   width:30px;
 }
 
-/*-------------------------------------------------------------------------- 
+/*--------------------------------------------------------------------------
   Formatting for page & standard document content
 /*--------------------------------------------------------------------------*/
 
@@ -159,7 +160,7 @@ td.title, thead {
 #main li { font-size: 11pt; margin: 5px 0px 5px 0px; }
 #main strong { font-weight:700; }
 
-/*-------------------------------------------------------------------------- 
+/*--------------------------------------------------------------------------
   Formatting for API reference
 /*--------------------------------------------------------------------------*/
 
@@ -191,8 +192,8 @@ td.title, thead {
 .github-link .normal { display: block; }
 .github-link:hover .normal { display: none; }
 
-/*-------------------------------------------------------------------------- 
-  Links 
+/*--------------------------------------------------------------------------
+  Links
 /*--------------------------------------------------------------------------*/
 
 h1 a, h1 a:hover, h1 a:focus,
@@ -202,14 +203,14 @@ h4 a, h4 a:hover, h4 a:focus,
 h5 a, h5 a:hover, h5 a:focus,
 h6 a, h6 a:hover, h6 a:focus { color : inherit; text-decoration : inherit; outline:none }
 
-/*-------------------------------------------------------------------------- 
-  Additional formatting for the homepage 
+/*--------------------------------------------------------------------------
+  Additional formatting for the homepage
 /*--------------------------------------------------------------------------*/
 
-#nuget { 
+#nuget {
   margin-top:20px;
-  font-size: 11pt; 
-  padding:20px; 
+  font-size: 11pt;
+  padding:20px;
 }
 
 #nuget pre {

--- a/docs/files/content/style_light.css
+++ b/docs/files/content/style_light.css
@@ -1,7 +1,7 @@
 @import url(https://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans+Mono|Open+Sans:400,600,700);
 
-/*-------------------------------------------------------------------------- 
-  Formatting for F# code snippets 
+/*--------------------------------------------------------------------------
+  Formatting for F# code snippets
 /*--------------------------------------------------------------------------*/
 
 /* identifier */
@@ -41,7 +41,7 @@ span.prep { color:#0000ff; }
 span.fsi { color:#808080; }
 
 /* omitted */
-span.omitted { 
+span.omitted {
 	background:#3c4e52;
   border-radius:5px;
 	color:#808080;
@@ -60,7 +60,7 @@ table.pre pre {
   padding:0px;
   margin:0px;
   border:none;
-} 
+}
 table.pre, pre.fssnip, pre {
   line-height:13pt;
   border:1px solid #d8d8d8;
@@ -72,7 +72,8 @@ table.pre, pre.fssnip, pre {
   background-color:#fdfdfd;
   padding:10px;
   border-radius:5px;
-  color:#000000;  
+  color:#000000;
+  max-width: none;
 }
 pre.fssnip code {
   font: 9pt 'Droid Sans Mono',consolas,monospace;
@@ -92,7 +93,7 @@ table.pre td.lines {
   width:30px;
 }
 
-/*-------------------------------------------------------------------------- 
+/*--------------------------------------------------------------------------
   Formatting for page & standard document content
 /*--------------------------------------------------------------------------*/
 
@@ -160,7 +161,7 @@ td.title, thead {
 #main li { font-size: 11pt; margin: 5px 0px 5px 0px; }
 #main strong { font-weight:700; }
 
-/*-------------------------------------------------------------------------- 
+/*--------------------------------------------------------------------------
   Formatting for API reference
 /*--------------------------------------------------------------------------*/
 
@@ -192,8 +193,8 @@ td.title, thead {
 .github-link .normal { display: block; }
 .github-link:hover .normal { display: none; }
 
-/*-------------------------------------------------------------------------- 
-  Links 
+/*--------------------------------------------------------------------------
+  Links
 /*--------------------------------------------------------------------------*/
 
 h1 a, h1 a:hover, h1 a:focus,
@@ -203,14 +204,14 @@ h4 a, h4 a:hover, h4 a:focus,
 h5 a, h5 a:hover, h5 a:focus,
 h6 a, h6 a:hover, h6 a:focus { color : inherit; text-decoration : inherit; outline:none }
 
-/*-------------------------------------------------------------------------- 
-  Additional formatting for the homepage 
+/*--------------------------------------------------------------------------
+  Additional formatting for the homepage
 /*--------------------------------------------------------------------------*/
 
-#nuget { 
+#nuget {
   margin-top:20px;
-  font-size: 11pt; 
-  padding:20px; 
+  font-size: 11pt;
+  padding:20px;
 }
 
 #nuget pre {

--- a/docs/tools/template-sidebyside.cshtml
+++ b/docs/tools/template-sidebyside.cshtml
@@ -8,7 +8,6 @@
     <meta name="author" content="@Properties["project-author"]">
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
-    <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
     <script src="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/js/bootstrap.min.js"></script>
     <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     <link href="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap-combined.min.css" rel="stylesheet">

--- a/docs/tools/template.cshtml
+++ b/docs/tools/template.cshtml
@@ -8,7 +8,6 @@
     <meta name="author" content="@Properties["project-author"]">
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
-    <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
     <script src="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/js/bootstrap.min.js"></script>
     <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     <link href="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap-combined.min.css" rel="stylesheet">

--- a/misc/literate/output/demo-doc.html
+++ b/misc/literate/output/demo-doc.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <!-- 
+    <!--
       The Literate sample
- parameters will be replaced with the 
+ parameters will be replaced with the
       document title extracted from the <h1> element or
       file name, if there is no <h1> heading
     -->
@@ -12,7 +12,6 @@
 </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script src="http://code.jquery.com/jquery-1.8.0.js"></script>
-    <script src="http://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
     <script src="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/js/bootstrap.min.js"></script>
     <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     <link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap-combined.min.css" rel="stylesheet">
@@ -30,12 +29,12 @@
         <div class="span10" id="main">
           <h1>Literate sample</h1>
 
-<p>This file demonstrates how to write Markdown document with 
-embedded F# snippets that can be transformed into nice HTML 
+<p>This file demonstrates how to write Markdown document with
+embedded F# snippets that can be transformed into nice HTML
 using the <code>literate.fsx</code> script from the <a href="http://tpetricek.github.com/FSharp.Formatting">F# Formatting
 package</a>.</p>
 
-<p>In this case, the document itself is a valid Markdown and 
+<p>In this case, the document itself is a valid Markdown and
 you can use standard Markdown features to format the text:</p>
 
 <ul>
@@ -47,9 +46,9 @@ you can use standard Markdown features to format the text:</p>
 
 <h2>Writing F# code</h2>
 
-<p>In standard Markdown, you can include code snippets by 
-writing a block indented by four spaces and the code 
-snippet will be turned into a <code>&lt;pre&gt;</code> element. If you do 
+<p>In standard Markdown, you can include code snippets by
+writing a block indented by four spaces and the code
+snippet will be turned into a <code>&lt;pre&gt;</code> element. If you do
 the same using Literate F# tool, the code is turned into
 a nicely formatted F# snippet:</p>
 
@@ -64,8 +63,8 @@ a nicely formatted F# snippet:</p>
 </td>
 <td class="snippet"><pre class="fssnip">
 <span class="c">/// The Hello World of functional languages!</span>
-<span class="k">let</span> <span class="k">rec</span> <span onmouseout="hideTip(event, 'fs1', 1)" onmouseover="showTip(event, 'fs1', 1)" class="f">factorial</span> <span onmouseout="hideTip(event, 'fs2', 2)" onmouseover="showTip(event, 'fs2', 2)" class="i">x</span> <span class="o">=</span> 
-  <span class="k">if</span> <span onmouseout="hideTip(event, 'fs2', 3)" onmouseover="showTip(event, 'fs2', 3)" class="i">x</span> <span class="o">=</span> <span class="n">0</span> <span class="k">then</span> <span class="n">1</span> 
+<span class="k">let</span> <span class="k">rec</span> <span onmouseout="hideTip(event, 'fs1', 1)" onmouseover="showTip(event, 'fs1', 1)" class="f">factorial</span> <span onmouseout="hideTip(event, 'fs2', 2)" onmouseover="showTip(event, 'fs2', 2)" class="i">x</span> <span class="o">=</span>
+  <span class="k">if</span> <span onmouseout="hideTip(event, 'fs2', 3)" onmouseover="showTip(event, 'fs2', 3)" class="i">x</span> <span class="o">=</span> <span class="n">0</span> <span class="k">then</span> <span class="n">1</span>
   <span class="k">else</span> <span onmouseout="hideTip(event, 'fs2', 4)" onmouseover="showTip(event, 'fs2', 4)" class="i">x</span> <span class="o">*</span> (<span onmouseout="hideTip(event, 'fs1', 5)" onmouseover="showTip(event, 'fs1', 5)" class="f">factorial</span> (<span onmouseout="hideTip(event, 'fs2', 6)" onmouseover="showTip(event, 'fs2', 6)" class="i">x</span> <span class="o">-</span> <span class="n">1</span>))
 
 <span class="k">let</span> <span onmouseout="hideTip(event, 'fs3', 7)" onmouseover="showTip(event, 'fs3', 7)" class="i">f10</span> <span class="o">=</span> <span onmouseout="hideTip(event, 'fs1', 8)" onmouseover="showTip(event, 'fs1', 8)" class="f">factorial</span> <span class="n">10</span>
@@ -76,14 +75,14 @@ a nicely formatted F# snippet:</p>
 
 <h2>Hiding code</h2>
 
-<p>If you want to include some code in the source code, 
-but omit it from the output, you can use the <code>hide</code> 
-command. You can also use <code>module=...</code> to specify that 
-the snippet should be placed in a separate module 
+<p>If you want to include some code in the source code,
+but omit it from the output, you can use the <code>hide</code>
+command. You can also use <code>module=...</code> to specify that
+the snippet should be placed in a separate module
 (e.g. to avoid duplicate definitions).</p>
 
-<p>The value will be deffined in the F# code that is 
-processed and so you can use it from other (visible) 
+<p>The value will be deffined in the F# code that is
+processed and so you can use it from other (visible)
 code and get correct tool tips:</p>
 
 <table class="pre"><tr><td class="lines"><pre class="fssnip">
@@ -99,9 +98,9 @@ code and get correct tool tips:</p>
 
 <h2>Including other snippets</h2>
 
-<p>When writing literate programs as Markdown documents, 
-you can also include snippets in other languages. 
-These will not be colorized and processed as F# 
+<p>When writing literate programs as Markdown documents,
+you can also include snippets in other languages.
+These will not be colorized and processed as F#
 code samples:</p>
 
 <table class="pre"><tr><td><pre lang="csharp">Console.WriteLine(<span class="s">"Hello world!"</span>);
@@ -116,7 +115,7 @@ code samples:</p>
 <div class="tip" id="fs4">val answer : int<br /><br />Full name: demo.answer</div>
 <div class="tip" id="fs5">module Hidden<br /><br />from demo</div>
 <div class="tip" id="fs6">val answer : int<br /><br />Full name: demo.Hidden.answer<br /><em><br /><br />&#160;This is a hidden answer</em></div>
-          
+
         </div>
         <div class="span1"></div>
       </div>

--- a/misc/literate/output/demo-script.html
+++ b/misc/literate/output/demo-script.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <!-- 
+    <!--
       The Literate sample
- parameters will be replaced with the 
+ parameters will be replaced with the
       document title extracted from the <h1> element or
       file name, if there is no <h1> heading
     -->
@@ -12,7 +12,6 @@
 </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script src="http://code.jquery.com/jquery-1.8.0.js"></script>
-    <script src="http://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
     <script src="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/js/bootstrap.min.js"></script>
     <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     <link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap-combined.min.css" rel="stylesheet">
@@ -36,7 +35,7 @@ using the <code>literate.fsx</code> script from the <a href="http://tpetricek.gi
 package</a>.</p>
 
 <p>As you can see, a comment starting with double asterisk
-is treated as part of the document and is transformed 
+is treated as part of the document and is transformed
 using Markdown, which means that you can use:</p>
 
 <ul>
@@ -49,7 +48,7 @@ using Markdown, which means that you can use:</p>
 <h2>Writing F# code</h2>
 
 <p>Code that is not inside comment will be formatted as
-a sample snippet (which also means that you can 
+a sample snippet (which also means that you can
 run it in Visual Studio or MonoDevelop).</p>
 
 <table class="pre"><tr><td class="lines"><pre class="fssnip">
@@ -63,8 +62,8 @@ run it in Visual Studio or MonoDevelop).</p>
 </td>
 <td class="snippet"><pre class="fssnip">
 <span class="c">/// The Hello World of functional languages!</span>
-<span class="k">let</span> <span class="k">rec</span> <span onmouseout="hideTip(event, 'fs1', 1)" onmouseover="showTip(event, 'fs1', 1)" class="f">factorial</span> <span onmouseout="hideTip(event, 'fs2', 2)" onmouseover="showTip(event, 'fs2', 2)" class="i">x</span> <span class="o">=</span> 
-  <span class="k">if</span> <span onmouseout="hideTip(event, 'fs2', 3)" onmouseover="showTip(event, 'fs2', 3)" class="i">x</span> <span class="o">=</span> <span class="n">0</span> <span class="k">then</span> <span class="n">1</span> 
+<span class="k">let</span> <span class="k">rec</span> <span onmouseout="hideTip(event, 'fs1', 1)" onmouseover="showTip(event, 'fs1', 1)" class="f">factorial</span> <span onmouseout="hideTip(event, 'fs2', 2)" onmouseover="showTip(event, 'fs2', 2)" class="i">x</span> <span class="o">=</span>
+  <span class="k">if</span> <span onmouseout="hideTip(event, 'fs2', 3)" onmouseover="showTip(event, 'fs2', 3)" class="i">x</span> <span class="o">=</span> <span class="n">0</span> <span class="k">then</span> <span class="n">1</span>
   <span class="k">else</span> <span onmouseout="hideTip(event, 'fs2', 4)" onmouseover="showTip(event, 'fs2', 4)" class="i">x</span> <span class="o">*</span> (<span onmouseout="hideTip(event, 'fs1', 5)" onmouseover="showTip(event, 'fs1', 5)" class="f">factorial</span> (<span onmouseout="hideTip(event, 'fs2', 6)" onmouseover="showTip(event, 'fs2', 6)" class="i">x</span> <span class="o">-</span> <span class="n">1</span>))
 
 <span class="k">let</span> <span onmouseout="hideTip(event, 'fs3', 7)" onmouseover="showTip(event, 'fs3', 7)" class="i">f10</span> <span class="o">=</span> <span onmouseout="hideTip(event, 'fs1', 8)" onmouseover="showTip(event, 'fs1', 8)" class="f">factorial</span> <span class="n">10</span>
@@ -75,8 +74,8 @@ run it in Visual Studio or MonoDevelop).</p>
 
 <h2>Hiding code</h2>
 
-<p>If you want to include some code in the source code, 
-but omit it from the output, you can use the <code>hide</code> 
+<p>If you want to include some code in the source code,
+but omit it from the output, you can use the <code>hide</code>
 command.</p>
 
 <p>The value will be deffined in the F# code and so you
@@ -97,7 +96,7 @@ tool tips:</p>
 <h2>Moving code around</h2>
 
 <p>Sometimes, it is useful to first explain some code that
-has to be located at the end of the snippet (perhaps 
+has to be located at the end of the snippet (perhaps
 because it uses some definitions discussed in the middle).
 This can be done using <code>include</code> and <code>define</code> commands.</p>
 
@@ -111,7 +110,7 @@ it uses <code>laterFunction</code>:</p>
 </pre>
 </td>
 <td class="snippet"><pre class="fssnip">
-<span class="k">let</span> <span onmouseout="hideTip(event, 'fs7', 13)" onmouseover="showTip(event, 'fs7', 13)" class="i">sample</span> <span class="o">=</span> 
+<span class="k">let</span> <span onmouseout="hideTip(event, 'fs7', 13)" onmouseover="showTip(event, 'fs7', 13)" class="i">sample</span> <span class="o">=</span>
   <span onmouseout="hideTip(event, 'fs6', 14)" onmouseover="showTip(event, 'fs6', 14)" class="f">laterFunction</span>()
   <span class="o">|&gt;</span> <span onmouseout="hideTip(event, 'fs8', 15)" onmouseover="showTip(event, 'fs8', 15)" class="f">printfn</span> <span class="s">&quot;Got: </span><span class="pf">%s</span><span class="s">&quot;</span>
 </pre>
@@ -127,16 +126,16 @@ it uses <code>laterFunction</code>:</p>
 </pre>
 </td>
 <td class="snippet"><pre class="fssnip">
-<span class="k">let</span> <span onmouseout="hideTip(event, 'fs6', 12)" onmouseover="showTip(event, 'fs6', 12)" class="f">laterFunction</span>() <span class="o">=</span> 
+<span class="k">let</span> <span onmouseout="hideTip(event, 'fs6', 12)" onmouseover="showTip(event, 'fs6', 12)" class="f">laterFunction</span>() <span class="o">=</span>
   <span class="s">&quot;Not very difficult, is it?&quot;</span>
 </pre>
 </td>
 </tr>
 </table>
 
-<p>This example covers pretty much all features that are 
-currently implemented in <code>literate.fsx</code>, but feel free 
-to <a href="https://github.com/tpetricek/FSharp.Formatting">fork the project on GitHub</a> and add more 
+<p>This example covers pretty much all features that are
+currently implemented in <code>literate.fsx</code>, but feel free
+to <a href="https://github.com/tpetricek/FSharp.Formatting">fork the project on GitHub</a> and add more
 features or report bugs!</p>
 
 <h2>Other features</h2>
@@ -168,7 +167,7 @@ This might be useful to generate nice documents from tests:</p>
 <div class="tip" id="fs7">val sample : unit<br /><br />Full name: Demo.sample</div>
 <div class="tip" id="fs8">val printfn : format:Printf.TextWriterFormat&lt;&#39;T&gt; -&gt; &#39;T<br /><br />Full name: Microsoft.FSharp.Core.ExtraTopLevelOperators.printfn</div>
 <div class="tip" id="fs9">val ( 1 + 1 should be equal to 2 ) : unit -&gt; bool<br /><br />Full name: Demo.( 1 + 1 should be equal to 2 )</div>
-          
+
         </div>
         <div class="span1"></div>
       </div>

--- a/misc/literate/templates/template-file.html
+++ b/misc/literate/templates/template-file.html
@@ -2,15 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <!-- 
-      The {page-title} parameters will be replaced with the 
+    <!--
+      The {page-title} parameters will be replaced with the
       document title extracted from the <h1> element or
       file name, if there is no <h1> heading
     -->
     <title>{page-title}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script src="http://code.jquery.com/jquery-1.8.0.js"></script>
-    <script src="http://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
     <script src="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/js/bootstrap.min.js"></script>
     <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     <link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap-combined.min.css" rel="stylesheet">
@@ -27,7 +26,7 @@
         <div class="span1"></div>
         <div class="span10" id="main">
           {document}
-          {tooltips}          
+          {tooltips}
         </div>
         <div class="span1"></div>
       </div>

--- a/misc/literate/templates/template-project.html
+++ b/misc/literate/templates/template-project.html
@@ -2,8 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <!-- 
-      The {page-title} parameters will be replaced with the 
+    <!--
+      The {page-title} parameters will be replaced with the
       document title extracted from the <h1> element or
       file name, if there is no <h1> heading
     -->
@@ -12,7 +12,6 @@
     <meta name="description" content="{page-description}">
     <meta name="author" content="{page-author}">
     <script src="http://code.jquery.com/jquery-1.8.0.js"></script>
-    <script src="http://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
     <script src="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/js/bootstrap.min.js"></script>
     <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     <link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap-combined.min.css" rel="stylesheet">
@@ -36,7 +35,7 @@
       <div class="row">
         <div class="span9" id="main">
           {document}
-          {tooltips}          
+          {tooltips}
         </div>
         <div class="span3">
 
@@ -45,7 +44,7 @@
             <li><a href="../index.html">Home page</a></li>
             <!--
 
-              Here you can add links to other pages of the documentation 
+              Here you can add links to other pages of the documentation
               The 'divider' element creates a separator and additional
               'nav-header' can be used to add sub-headings in the menu:
 

--- a/misc/templates/template.cshtml
+++ b/misc/templates/template.cshtml
@@ -8,7 +8,6 @@
     <meta name="author" content="@Properties["project-author"]">
 
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
-    <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
     <script src="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/js/bootstrap.min.js"></script>
     <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     <link href="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap-combined.min.css" rel="stylesheet">
@@ -50,7 +49,7 @@
             <li><a href="@Properties["project-github"]/blob/master/LICENSE.md">License (Apache 2.0)</a></li>
             <li><a href="@Properties["project-github"]/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
             <li><a href="@Properties["project-github"]/blob/master/CONTRIBUTING.md">Contributing to @Properties["project-name"]</a></li>
-            
+
             <li class="nav-header">Documentation</li>
 
             <li><a href="@Root/index.html">Introduction</a></li>

--- a/tests/FSharp.Literate.Tests/files/template.html
+++ b/tests/FSharp.Literate.Tests/files/template.html
@@ -2,15 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <!-- 
-      The {page-title} parameters will be replaced with the 
+    <!--
+      The {page-title} parameters will be replaced with the
       document title extracted from the <h1> element or
       file name, if there is no <h1> heading
     -->
     <title>{page-title}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script src="http://code.jquery.com/jquery-1.8.0.js"></script>
-    <script src="http://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
     <script src="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/js/bootstrap.min.js"></script>
     <link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap-combined.min.css" rel="stylesheet">
     <link type="text/css" rel="stylesheet" href="content/style.css" />
@@ -26,7 +25,7 @@
         <div class="span1"></div>
         <div class="span10" id="main">
           {document}
-          {tooltips}          
+          {tooltips}
         </div>
         <div class="span1"></div>
       </div>


### PR DESCRIPTION
This PR fixes the display of Code-blocks bigger than the screen size in Safari as reported in #230 by "removing" the `width: 100%` style assigned for tables.

__Example of rendering of current documentation on Safari OSX__
![f formatting code formatting 2016-02-02 01-09-30](https://cloud.githubusercontent.com/assets/403823/12735695/12dd9494-c94a-11e5-991e-ddf05dcf2279.png)

__After the change proposed in this PR__
![f formatting code formatting 2016-02-02 01-02-56](https://cloud.githubusercontent.com/assets/403823/12735705/28a6ef14-c94a-11e5-9b3e-2561f31035a5.png)


Also, references to jQuery-UI were removed as it is not used and 250kb is downloaded by referencing it.