### PR TITLE
End blockquote on a line with an empty blockquote. For #355

### DIFF
--- a/src/FSharp.Markdown/MarkdownParser.fs
+++ b/src/FSharp.Markdown/MarkdownParser.fs
@@ -630,12 +630,21 @@ let (|LinesUntilBlockquoteEnds|) input =
 /// Recognizes blockquote - continues taking paragraphs
 /// starting with '>' until there is something else
 let rec (|Blockquote|_|) = function
+  | EmptyBlockquote(Lines.TrimBlankStart rest) ->
+      Some ([""], rest)
   | BlockquoteStart(line)::LinesUntilBlockquoteEnds(continued, Lines.TrimBlankStart rest) ->
       let moreLines, rest =
         match rest with
         | Blockquote(lines, rest) -> lines, rest
         | _ -> [], rest
       Some (line::continued @ moreLines, rest)
+  | _ -> None
+
+/// Recognizes a special case: an empty blockquote line should terminate
+/// the blockquote if the next line is not a blockquote
+and (|EmptyBlockquote|_|) = function
+  | BlockquoteStart(String.WhiteSpace) :: Blockquote(_) -> None
+  | BlockquoteStart(String.WhiteSpace) :: rest -> Some rest
   | _ -> None
 
 /// Recognizes Latex block - start with "$$$"

--- a/tests/FSharp.Markdown.Tests/Markdown.fs
+++ b/tests/FSharp.Markdown.Tests/Markdown.fs
@@ -323,7 +323,17 @@ let ``Transform tables with delimiters in code or math correctly``() =
     |> shouldEqualNoWhiteSpace expected
 
 [<Test>]
-let ``Parse and transform empty blockquote followed by content``() =
+let ``Parse empty blockquote followed by content``() =
+    let doc = ">
+a"
+    let expected = [ QuotedBlock []
+                     Paragraph [ Literal "a" ] ]
+
+    (Markdown.Parse doc).Paragraphs
+    |> shouldEqual expected
+
+[<Test>]
+let ``Parse blockquote teriminated by empty blockquote line and followed by content``() =
     let doc = ">a
 >
 a"

--- a/tests/FSharp.Markdown.Tests/Markdown.fs
+++ b/tests/FSharp.Markdown.Tests/Markdown.fs
@@ -321,3 +321,14 @@ let ``Transform tables with delimiters in code or math correctly``() =
 </table>     """ |> properNewLines
     Markdown.TransformHtml doc
     |> shouldEqualNoWhiteSpace expected
+
+[<Test>]
+let ``Parse and transform empty blockquote followed by content``() =
+    let doc = ">a
+>
+a"
+    let expected = [ QuotedBlock [ Paragraph [ Literal "a" ] ]
+                     Paragraph [ Literal "a" ] ]
+
+    (Markdown.Parse doc).Paragraphs
+    |> shouldEqual expected


### PR DESCRIPTION
This stops an exception being thrown but it also changes the behaviour for this case:

```fsharp
">a
>
a"
```
Previous output:
```html
<blockquote>
<p>a</p>
<p>a</p>
</blockquote>
```
New output:
```html
<blockquote>
<p>a</p>
</blockquote>
<p>a</p>
```

I'm not sure if we want this behaviour change as it's a bit of a weird edge case, but it does agree with: http://spec.commonmark.org/dingus/