### PR TITLE
Enabled and fixed 3 CommonMark test sections

### DIFF
--- a/FSharp.Formatting.sln
+++ b/FSharp.Formatting.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 12.0.31101.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "project", "project", "{194BD478-0DB5-44F3-A6C2-1FC75D3F3294}"
 	ProjectSection(SolutionItems) = preProject
@@ -104,6 +104,11 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "crefLib4", "tests\FSharp.MetadataFormat.Tests\files\crefLib\crefLib4.csproj", "{98624699-1B2F-4636-A3F7-EC72343CB2FD}"
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharp.Formatting.Common", "src\FSharp.Formatting.Common\FSharp.Formatting.Common.fsproj", "{91BAD90E-BF3B-4646-A1A7-1568F8F25075}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{AFB9168D-4763-472D-B895-F61A049B75BF}"
+	ProjectSection(SolutionItems) = preProject
+		tests\commonmark_spec.json = tests\commonmark_spec.json
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/FSharp.Markdown/HtmlFormatting.fs
+++ b/src/FSharp.Markdown/HtmlFormatting.fs
@@ -77,7 +77,7 @@ let rec formatSpan (ctx:FormattingContext) = function
   | AnchorLink(id) -> ctx.Writer.Write("<a name=\"" + id + "\">&#160;</a>") 
   | EmbedSpans(cmd) -> formatSpans ctx (cmd.Render())
   | Literal(str) -> ctx.Writer.Write(str)
-  | HardLineBreak -> ctx.Writer.WriteLine("<br />")
+  | HardLineBreak -> ctx.Writer.Write("<br />" + ctx.Newline)
   | IndirectLink(body, _, LookupKey ctx.Links (link, title)) 
   | DirectLink(body, (link, title)) -> 
       ctx.Writer.Write("<a href=\"")

--- a/src/FSharp.Markdown/MarkdownParser.fs
+++ b/src/FSharp.Markdown/MarkdownParser.fs
@@ -6,8 +6,8 @@
 module internal FSharp.Markdown.Parser
 
 open System
-open System.IO
 open System.Collections.Generic
+open System.Text.RegularExpressions
 
 open FSharp.Patterns
 open FSharp.Collections
@@ -584,19 +584,14 @@ let (|EmacsTableBlock|_|) input =
 
 /// Recognizes a start of a blockquote
 let (|BlockquoteStart|_|) (line:string) =
-  let rec spaces i =
-    // Too many spaces or beyond the end of line
-    if i = 4 || i = line.Length then None
-    elif line.[i] = '>' then
-      // Blockquote - does it have additional space?
-      let start =
-        if (i + 1) = line.Length || line.[i+1] <> ' ' then i + 1
-        else i + 2
-      Some(line.Substring(start))
-    elif line.[i] = ' ' then spaces (i + 1)
-    //elif line.[i] = '\t' then spaces (i + 4)
-    else None
-  spaces 0
+  let regex =
+    "^ *" // Maybe leading spaces
+    + ">" // Blockquote character
+    + "\s?" // Maybe one whitespace character
+    + "(.*)" // Capture everything else
+  let match' = Regex.Match(line, regex)
+  if match'.Success then Some (match'.Groups.Item(1)).Value
+  else None
 
 /// Takes lines that belong to a continuing paragraph until
 /// a white line or start of other paragraph-item is found

--- a/src/FSharp.Markdown/MarkdownParser.fs
+++ b/src/FSharp.Markdown/MarkdownParser.fs
@@ -581,11 +581,10 @@ let (|EmacsTableBlock|_|) input =
     loop true None [] emptyCur rest
   | _ -> None
 
-
 /// Recognizes a start of a blockquote
 let (|BlockquoteStart|_|) (line:string) =
   let regex =
-    "^ *" // Maybe leading spaces
+    "^ {0,3}" // Up to three leading spaces
     + ">" // Blockquote character
     + "\s?" // Maybe one whitespace character
     + "(.*)" // Capture everything else

--- a/tests/FSharp.Markdown.Tests/CommonMarkSpecTest.fs
+++ b/tests/FSharp.Markdown.Tests/CommonMarkSpecTest.fs
@@ -21,7 +21,8 @@ let enabledSections =
   [ "Fenced code blocks"
     "Indented code blocks"
     "Paragraphs"
-    "Precedence" ]
+    "Precedence"
+    "Tabs" ]
 
 let getTests () =
   sample

--- a/tests/FSharp.Markdown.Tests/CommonMarkSpecTest.fs
+++ b/tests/FSharp.Markdown.Tests/CommonMarkSpecTest.fs
@@ -19,7 +19,8 @@ open FSharp.Markdown
 
 let enabledSections =
   [ "Fenced code blocks"
-    "Indented code blocks"]
+    "Indented code blocks"
+    "Paragraphs" ]
 
 let getTests () =
   sample

--- a/tests/FSharp.Markdown.Tests/CommonMarkSpecTest.fs
+++ b/tests/FSharp.Markdown.Tests/CommonMarkSpecTest.fs
@@ -20,7 +20,8 @@ open FSharp.Markdown
 let enabledSections =
   [ "Fenced code blocks"
     "Indented code blocks"
-    "Paragraphs" ]
+    "Paragraphs"
+    "Precedence" ]
 
 let getTests () =
   sample

--- a/tests/FSharp.Markdown.Tests/Markdown.fs
+++ b/tests/FSharp.Markdown.Tests/Markdown.fs
@@ -342,3 +342,11 @@ a"
 
     (Markdown.Parse doc).Paragraphs
     |> shouldEqual expected
+
+[<Test>]
+let ``Parse blockquote with three leading spaces``() =
+    let doc = "   >a"
+    let expected = [ QuotedBlock [ Paragraph [ Literal "a" ] ] ]
+
+    (Markdown.Parse doc).Paragraphs
+    |> shouldEqual expected


### PR DESCRIPTION
I enabled "Paragraphs", "Precedence" and "Tabs" and fixed some failing tests.

Note that while fixing `(|BlockquoteStart|_|)`, I rewrote it with regex as it seemed much clearer.