### PR TITLE
Fix tooltip flickering in CSS

### DIFF
--- a/docs/files/content/style.css
+++ b/docs/files/content/style.css
@@ -54,6 +54,7 @@ div.tip {
 	padding:6px 8px 6px 8px;
 	display:none;
   color:#d1d1d1;
+  pointer-events:none;
 }
 table.pre pre {
   padding:0px;

--- a/docs/files/content/style_light.css
+++ b/docs/files/content/style_light.css
@@ -55,6 +55,7 @@ div.tip {
 	padding:6px 8px 6px 8px;
 	display:none;
   color:#000000;
+  pointer-events:none;
 }
 table.pre pre {
   padding:0px;

--- a/src/FSharp.CodeFormat/files/style.css
+++ b/src/FSharp.CodeFormat/files/style.css
@@ -36,6 +36,7 @@ div.tip
 	border:1px solid #606060;
 	background:#ffffd0;
 	display:none;
+	pointer-events:none;
 }
 
 h2


### PR DESCRIPTION
Fixes #405.

This solution uses `pointer-events: none` to ensure that tooltips don't receive mouseover and mouseout events, thereby removing the flicker that occurs when the tooltip overlaps its parent element.

Browser compatibility: http://caniuse.com/#feat=pointer-events
