### PR TITLE
Fix tooltip flickering in Javascript

### DIFF
--- a/docs/files/content/tips.js
+++ b/docs/files/content/tips.js
@@ -2,7 +2,13 @@ var currentTip = null;
 var currentTipElement = null;
 
 function hideTip(evt, name, unique) {
+    // Fix flicker when tooltip overlaps parent element
+    // See http://www.quirksmode.org/js/events_mouse.html
+    if (!evt) var evt = window.event;
+    var movedInto = evt.relatedTarget || evt.toElement;
     var el = document.getElementById(name);
+    // Avoid flicker: don't hide if we're moving into the tooltip div
+    if (movedInto == el) return;
     el.style.display = "none";
     currentTip = null;
 }

--- a/src/FSharp.CodeFormat/HtmlFormatting.fs
+++ b/src/FSharp.CodeFormat/HtmlFormatting.fs
@@ -50,7 +50,8 @@ type ToolTipFormatter(prefix) =
   /// Returns all generated tool tip elements
   member x.WriteTipElements (writer:TextWriter) = 
     for (KeyValue(_, (index, html))) in tips do
-      writer.WriteLine(sprintf "<div class=\"tip\" id=\"%s%d\">%s</div>" prefix index html)
+      let id = sprintf "%s%d" prefix index
+      writer.WriteLine(sprintf "<div class=\"tip\" id=\"%s\" onmouseout=\"hideTip(event, '%s', 0)\"\>%s</div>" id id html)
 
 /// Represents context used by the formatter
 type FormattingContext = 

--- a/src/FSharp.CodeFormat/files/tips.js
+++ b/src/FSharp.CodeFormat/files/tips.js
@@ -3,7 +3,13 @@ var currentTipElement = null;
 
 function hideTip(evt, name, unique)
 {
+  // Fix flicker when tooltip overlaps parent element
+  // See http://www.quirksmode.org/js/events_mouse.html
+  if (!evt) var evt = window.event;
+  var movedInto = evt.relatedTarget || evt.toElement;
   var el = document.getElementById(name);
+  // Avoid flicker: don't hide if we're moving into the tooltip div
+  if (movedInto == el) return;
   el.style.display = "none";
   currentTip = null;
 }


### PR DESCRIPTION
Fixes #405.

This solution eliminates the flicker when a tooltip overlaps its parent element. It also adds a mouseout event to the tooltips to ensure that they'll be dismissed when the user moves the mouse out of them.