### PR TITLE
Fixes issues with comments and keywords in Paket highlighter

### DIFF
--- a/src/CSharpFormat/PaketFormat.cs
+++ b/src/CSharpFormat/PaketFormat.cs
@@ -11,13 +11,16 @@ namespace Manoli.Utils.CSharpFormat
 	{
         /// <summary>
         /// Regular expression string to match single line and multi-line 
-        /// comments (// and (* *)). Single line comments should not have 
-        /// a : before them to avoid color as comments URLs. For example
-        /// (source https://nuget.org/api/v2)
+        /// comments (// and (* *)). Single line comments should have to have 
+        /// a space after them to avoid color as comments URLs and paths. For example
+        /// ```
+        ///     source https://nuget.org/api/v2
+        //      cache //hive/dependencies
+        /// ```
         /// </summary>
         protected override string CommentRegEx
         {
-            get { return @"\(\*.*?\*\)|(?<!\:|\:/)//.*?(?:\r|\n|$)"; }
+            get { return @"\(\*.*?\*\)|//\s.*?(?:\r|\n|$)"; }
         }
         
         /// <summary>
@@ -33,8 +36,13 @@ namespace Manoli.Utils.CSharpFormat
         /// </summary>
         protected override string Keywords
         {
-            get { return "source nuget\\s github\\s gist\\s git\\s http\\s group framework version_in_path content " 
-              + "copy_local redirects import_targets references cache strategy lowest_matching NUGET GITHUB GROUP GIT HTTP specs remote File"; }
+            get 
+            { 
+                return "source nuget github gist git http group framework version_in_path content"
+                    + " copy_local redirects import_targets references cache strategy lowest_matching NUGET"
+                    + " specs remote File username password copy_content_to_output_dir GITHUB GROUP GIT HTTP"
+                    + " CopyToOutputDirectory";
+            }
         }
         
         /// <summary>
@@ -65,11 +73,9 @@ namespace Manoli.Utils.CSharpFormat
         {
             if (separated.Length == 0) return "";
             var sb = new StringBuilder(separated);
-          
-            Sanitize(sb);
             
-            sb.Replace(" ", @"\b|\b");
-            return @"\b" + sb.ToString() + @"\b";
+            sb.Replace(" ", @"(?=\:?(?:\s|$))|(?<=\s|^)");
+            return @"(?<=\s|^)" + sb.ToString() + @"(?=\:?(?:\s|$))";
         }
     }
 }


### PR DESCRIPTION
Fixes  ##397

I have modified the Regex for comments and keywords of Paket and added some more keywords I found in the docs.

![image](https://cloud.githubusercontent.com/assets/403823/15567949/9d523358-2329-11e6-86de-f36b51102eaf.png)

![image](https://cloud.githubusercontent.com/assets/403823/15567966/c32bca80-2329-11e6-94c0-a8db79d79b79.png)

There are two caveats although:
* Keywords should have a space after the keyword or after the ":" in order to be recognized and highlighted.
* Comments should have a space after the "//" 